### PR TITLE
feat: initial implementation — deterministic quality scorer for Claude Code skills

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Keep the build context small. NOTE: .docker-build/ is intentionally NOT ignored —
+# the Makefile stages the skillspector checkout there for the build.
+.venv/
+.git/
+.gitignore
+**/__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+tests/
+.docker-build/skillspector/.git/
+.docker-build/skillspector/.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+.docker-build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.15
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.1.0
+    hooks:
+      - id: mypy
+        args: [--strict, src/]
+        additional_dependencies:
+          - "pyyaml>=6.0.1"
+          - "typer>=0.12"
+          - "rich>=14.3.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for skillspector-quality.
+#
+# skillspector is not on PyPI, so it is installed from a local checkout that the
+# Makefile stages into ./.docker-build/skillspector before building (the build
+# context cannot reach ../SkillRater on its own). Build via `make docker-build`,
+# not a bare `docker build`.
+
+# --- builder: install everything into a self-contained venv ------------------
+FROM python:3.13-slim AS builder
+
+# uv for fast, reproducible installs.
+COPY --from=ghcr.io/astral-sh/uv:0.5.21 /uv /uvx /bin/
+ENV UV_LINK_MODE=copy
+
+# Build deps (fallback if a dependency lacks a wheel, e.g. yara-python).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN uv venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv PATH="/opt/venv/bin:$PATH"
+
+# Install the pinned skillspector first (its source is staged by the Makefile).
+COPY .docker-build/skillspector /src/skillspector
+RUN uv pip install /src/skillspector
+
+# Install skillspector-quality.
+COPY pyproject.toml README.md /src/app/
+COPY src /src/app/src
+RUN uv pip install /src/app
+
+# --- runtime: copy only the venv, no build tools -----------------------------
+FROM python:3.13.3-slim AS runtime
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN useradd -m -u 1001 appuser
+USER appuser
+
+WORKDIR /work
+
+# Run a scan by mounting a skill directory, e.g.:
+#   docker run --rm -v "$PWD/my-skill:/work/skill:ro" skillspector-quality scan /work/skill
+ENTRYPOINT ["python", "-m", "skillspector_quality"]
+CMD ["--help"]

--- a/Formula/skillspector-quality.rb
+++ b/Formula/skillspector-quality.rb
@@ -1,0 +1,103 @@
+# Homebrew formula for skillspector-quality.
+#
+# This file lives in Formula/ inside the project repo. To publish it:
+#
+#   1. Create a GitHub repo named  homebrew-tap  (or any name)
+#   2. Copy this file into that repo at  Formula/skillspector-quality.rb
+#   3. Users install with:
+#        brew tap lroettig/tap https://github.com/lroettig/homebrew-tap
+#        brew install skillspector-quality
+#
+# Before publishing:
+#   • Replace every PLACEHOLDER_* value (URL + sha256).
+#   • Run `brew audit --new Formula/skillspector-quality.rb` to validate.
+#   • Run `brew test skillspector-quality` to verify the test block.
+#
+# Generating sha256 for a tarball:
+#   curl -sL <url> | sha256sum
+#
+# Generating the resource stanzas for all Python deps automatically:
+#   pip install homebrew-pypi-poet
+#   poet --formula skillspector-quality   (run after `pip install skillspector-quality`)
+
+class SkillspectorQuality < Formula
+  include Language::Python::Virtualenv
+
+  desc "Deterministic authoring quality scorer for Claude Code skills (0-100)"
+  homepage "https://github.com/lroettig/skillspector-quality"
+
+  # Replace with the URL of your GitHub release tarball and its sha256.
+  url "https://github.com/lroettig/skillspector-quality/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "PLACEHOLDER_SKILLSPECTOR_QUALITY_SHA256"
+
+  license "MIT"
+
+  depends_on "python@3.13"
+
+  # --------------------------------------------------------------------------
+  # skillspector — upstream security scanner, not on PyPI.
+  # Replace URL + sha256 with your SkillRater release tarball.
+  # --------------------------------------------------------------------------
+  resource "skillspector" do
+    url "https://github.com/PLACEHOLDER_OWNER/SkillRater/archive/refs/tags/v2.1.4.tar.gz"
+    sha256 "PLACEHOLDER_SKILLSPECTOR_UPSTREAM_SHA256"
+  end
+
+  # --------------------------------------------------------------------------
+  # Python runtime dependencies.
+  # Run `poet --formula skillspector-quality` to regenerate these stanzas
+  # with exact versions and checksums after each release.
+  # --------------------------------------------------------------------------
+  resource "typer" do
+    url "https://files.pythonhosted.org/packages/PLACEHOLDER_TYPER.tar.gz"
+    sha256 "PLACEHOLDER_TYPER_SHA256"
+  end
+
+  resource "rich" do
+    url "https://files.pythonhosted.org/packages/PLACEHOLDER_RICH.tar.gz"
+    sha256 "PLACEHOLDER_RICH_SHA256"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/PLACEHOLDER_PYYAML.tar.gz"
+    sha256 "PLACEHOLDER_PYYAML_SHA256"
+  end
+
+  # Add all transitive deps reported by `poet` here.
+
+  def install
+    # Create an isolated virtualenv so the tool doesn't pollute Homebrew's Python.
+    venv = virtualenv_create(libexec, "python3.13")
+
+    # Install skillspector first — it is not on PyPI so we install from source.
+    resource("skillspector").stage do
+      venv.pip_install_and_link buildpath
+    end
+
+    # Install all remaining resources (pip dependencies).
+    venv.pip_install resources.reject { |r| r.name == "skillspector" }
+
+    # Install skillspector-quality itself.
+    venv.pip_install_and_link buildpath
+
+    # Expose the binary.
+    bin.install_symlink libexec/"bin/skillspector-quality"
+  end
+
+  test do
+    # Smoke-test: --help must exit 0 and print the command name.
+    assert_match "skillspector-quality", shell_output("#{bin}/skillspector-quality --help")
+
+    # Functional test: scan a minimal skill and expect a non-error exit.
+    (testpath/"SKILL.md").write <<~MARKDOWN
+      ---
+      name: brew-test
+      description: Minimal skill for Homebrew formula test.
+      ---
+      # Brew test skill
+
+      This skill exists to verify the Homebrew formula installs and runs correctly.
+    MARKDOWN
+    system bin/"skillspector-quality", "scan", testpath.to_s, "--no-llm"
+  end
+end

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# skillspector-quality — developer tasks
+#
+# skillspector is not on PyPI; it is installed from a local checkout.
+# Override its location with SKILLSPECTOR_SRC if it is not at ../SkillRater.
+
+IMAGE            ?= skillspector-quality
+TAG              ?= latest
+SKILLSPECTOR_SRC ?= ../SkillRater
+STAGE            := .docker-build/skillspector
+
+.PHONY: help install test lint docker-build docker-run clean
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+
+install: ## Set up the local venv (uv) with skillspector + this package
+	./scripts/install.sh "$(SKILLSPECTOR_SRC)"
+
+test: ## Run the test suite
+	. .venv/bin/activate && python -m pytest -q
+
+lint: ## Lint with ruff
+	. .venv/bin/activate && ruff check src tests
+
+docker-build: ## Build the Docker image (stages skillspector into the context)
+	@test -f "$(SKILLSPECTOR_SRC)/pyproject.toml" \
+		|| { echo "ERROR: no skillspector checkout at '$(SKILLSPECTOR_SRC)' (set SKILLSPECTOR_SRC)"; exit 1; }
+	@echo ">> Staging skillspector from $(SKILLSPECTOR_SRC)"
+	@rm -rf "$(STAGE)" && mkdir -p "$(STAGE)"
+	@bash -c 'trap "rm -rf $(STAGE)" EXIT; \
+		rsync -a --delete \
+		--exclude .git --exclude .venv --exclude __pycache__ --exclude "*.egg-info" \
+		"$(SKILLSPECTOR_SRC)/" "$(STAGE)/"; \
+		docker build -t "$(IMAGE):$(TAG)" .'
+	@echo ">> Built $(IMAGE):$(TAG)"
+
+docker-run: ## Scan the bundled fixture skill inside the image (no LLM)
+	docker run --rm -v "$(CURDIR)/tests/fixtures/good-skill:/work/skill:ro" \
+		"$(IMAGE):$(TAG)" scan /work/skill --no-llm
+
+clean: ## Remove the Docker staging dir
+	rm -rf .docker-build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "skillspector-quality"
+version = "0.1.0"
+description = "Deterministic authoring quality scorer for Claude Code skills. Rates SKILL.md bundles 0–100 across nine dimensions: information density, readability, topic coverage, structural coherence, code maintainability, and more"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12,<3.14"
+keywords = ["skills", "quality", "rating", "claude-code", "skillspector"]
+dependencies = [
+    # skillspector is not published to PyPI: install it editable first
+    # (`pip install -e ../SkillRater`), then `pip install -e .` is satisfied
+    # by the already-installed editable package. See README.
+    # Pinned to an exact version: this layer imports upstream internals
+    # (resolve_input, build_context, the analyzer registry), so the upstream
+    # version is part of our contract. Bump deliberately after testing a sync.
+    "skillspector==2.1.4",
+    "typer>=0.12,<2",
+    "rich>=14.3.0",
+    "pyyaml>=6.0.1",
+]
+
+[project.scripts]
+skillspector-quality = "skillspector_quality.cli:app"
+
+[project.optional-dependencies]
+code = [
+    "radon>=6.0",
+]
+dev = [
+    "pytest>=9.0.0",
+    "pytest-cov>=4.0",
+    "ruff>=0.15.0",
+    "mypy>=1.19.0",
+    "pre-commit>=3.0",
+    "radon>=6.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/skillspector_quality"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "B", "C4"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = ["integration: end-to-end tests that may call LLMs"]
+addopts = "-m 'not integration' --cov=skillspector_quality --cov-report=term-missing --cov-fail-under=70"
+
+[tool.mypy]
+strict = true
+python_version = "3.12"
+ignore_missing_imports = true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Install skillspector-quality and its (unpublished) skillspector dependency, using uv.
+#
+# skillspector is not on PyPI, so it must be installed editable from a local
+# checkout BEFORE this package. This script:
+#   1. creates a .venv with a compatible Python (>=3.12,<3.14 — skillspector
+#      forbids 3.14; uv fetches the interpreter if needed),
+#   2. installs skillspector editable from a local checkout,
+#   3. verifies the version matches the pin in pyproject.toml,
+#   4. installs skillspector-quality (with dev extras).
+#
+# Requires uv (https://docs.astral.sh/uv/).
+#
+# Usage:
+#   scripts/install.sh [SKILLSPECTOR_SRC]
+#
+#   SKILLSPECTOR_SRC  Path to the skillspector checkout.
+#                     Default: ../SkillRater (sibling of this repo).
+#                     May also be set via the SKILLSPECTOR_SRC env var.
+#
+# Examples:
+#   scripts/install.sh
+#   scripts/install.sh ../SkillRater
+#   SKILLSPECTOR_SRC=/path/to/skillspector scripts/install.sh
+
+set -euo pipefail
+
+# --- locate repo root (parent of this script's dir) --------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# --- require uv --------------------------------------------------------------
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: uv not found. Install it: https://docs.astral.sh/uv/getting-started/" >&2
+  echo "       e.g. curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+  exit 1
+fi
+
+# --- resolve the skillspector source path ------------------------------------
+SKILLSPECTOR_SRC="${1:-${SKILLSPECTOR_SRC:-${REPO_ROOT}/../SkillRater}}"
+if [ ! -f "${SKILLSPECTOR_SRC}/pyproject.toml" ]; then
+  echo "ERROR: no skillspector checkout at '${SKILLSPECTOR_SRC}'" >&2
+  echo "       Pass the path as an argument or set SKILLSPECTOR_SRC." >&2
+  exit 1
+fi
+SKILLSPECTOR_SRC="$(cd "${SKILLSPECTOR_SRC}" && pwd)"
+
+# --- create the venv with a compatible Python (uv fetches it if missing) -----
+echo ">> Creating .venv (Python >=3.12,<3.14) with uv"
+uv venv .venv --python 3.13 || uv venv .venv --python 3.12
+# shellcheck disable=SC1091
+source .venv/bin/activate
+echo ">> Using $(python --version 2>&1)"
+
+# --- install skillspector (editable) -----------------------------------------
+echo ">> Installing skillspector (editable) from ${SKILLSPECTOR_SRC}"
+uv pip install -e "${SKILLSPECTOR_SRC}"
+
+# --- verify version against the pin in pyproject.toml ------------------------
+PINNED="$(grep -oE 'skillspector==[0-9][0-9A-Za-z.\-]*' pyproject.toml | head -1 | cut -d= -f3 || true)"
+INSTALLED="$(python -c 'import importlib.metadata as m; print(m.version("skillspector"))')"
+echo ">> skillspector installed: ${INSTALLED} (pinned: ${PINNED:-unpinned})"
+if [ -n "${PINNED}" ] && [ "${PINNED}" != "${INSTALLED}" ]; then
+  echo "WARNING: checkout version ${INSTALLED} != pin ${PINNED}." >&2
+  echo "         Check out skillspector ${PINNED}, or update the pin in pyproject.toml." >&2
+fi
+
+# --- install this package (with dev extras) ----------------------------------
+echo ">> Installing skillspector-quality (editable, dev extras)"
+uv pip install -e '.[dev]'
+
+echo
+echo "Done. Activate the venv and run:"
+echo "  source .venv/bin/activate"
+echo "  python -m skillspector_quality scan ./my-skill/"

--- a/src/skillspector_quality/__init__.py
+++ b/src/skillspector_quality/__init__.py
@@ -1,0 +1,5 @@
+"""skillspector-quality: a quality rating layer on top of SkillSpector."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"

--- a/src/skillspector_quality/__main__.py
+++ b/src/skillspector_quality/__main__.py
@@ -1,0 +1,8 @@
+"""Enable ``python -m skillspector_quality``."""
+
+from __future__ import annotations
+
+from skillspector_quality.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/src/skillspector_quality/cli.py
+++ b/src/skillspector_quality/cli.py
@@ -1,0 +1,176 @@
+"""CLI for skillspector-quality.
+
+Thin wrapper: build initial state, invoke the quality-augmented graph, merge the upstream
+security report with the quality block, map to exit code. Mirrors ``skillspector scan``
+flags and adds ``--min-score``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+from langchain_core.runnables import RunnableConfig
+from rich.console import Console
+
+from skillspector_quality.graph import graph
+from skillspector_quality.quality.models import QualityReport
+from skillspector_quality.quality.render import (
+    quality_json_dict,
+    quality_markdown_section,
+    quality_sarif_properties,
+    unified_terminal_text,
+)
+
+app = typer.Typer(
+    name="skillspector-quality",
+    help="Quality rating layer for SkillSpector. Adds a 0-100 quality score alongside the security report.",
+    add_completion=False,
+    no_args_is_help=True,
+)
+
+console = Console()
+
+
+class FormatChoice(StrEnum):
+    terminal = "terminal"
+    json = "json"
+    markdown = "markdown"
+    sarif = "sarif"
+
+
+def _merge_output(result: dict[str, Any], fmt: FormatChoice, report: QualityReport) -> str:
+    """Combine the upstream security report_body with the quality block."""
+    report_body = result.get("report_body") or ""
+
+    if fmt == FormatChoice.terminal:
+        return unified_terminal_text(result, report)
+
+    if fmt == FormatChoice.markdown:
+        return report_body + "\n" + quality_markdown_section(report)
+
+    if fmt == FormatChoice.json:
+        try:
+            data = json.loads(report_body) if report_body else {}
+        except json.JSONDecodeError:
+            data = {}
+        data["quality_assessment"] = quality_json_dict(report)
+        return json.dumps(data, indent=2)
+
+    # sarif
+    sarif = result.get("sarif_report")
+    if not isinstance(sarif, dict):
+        try:
+            sarif = json.loads(report_body)
+        except json.JSONDecodeError:
+            sarif = {"runs": [{}]}
+    runs = sarif.get("runs") or [{}]
+    props = runs[0].get("properties") or {}
+    props["quality"] = quality_sarif_properties(report)
+    runs[0]["properties"] = props
+    sarif["runs"] = runs
+    return json.dumps(sarif, indent=2)
+
+
+def _write(text: str, output: Path | None, fmt: FormatChoice) -> None:
+    if output:
+        Path(output).write_text(text, encoding="utf-8")
+        console.print(f"Report saved to: {output}")
+    elif fmt == FormatChoice.terminal:
+        console.print(text)
+    else:
+        print(text)
+
+
+@app.command()
+def scan(
+    input_path: Annotated[
+        str,
+        typer.Argument(help="Path or URL to scan (directory, .md, .zip, Git URL, file URL)."),
+    ],
+    format: Annotated[
+        FormatChoice, typer.Option("--format", "-f", help="Output format.", case_sensitive=False)
+    ] = FormatChoice.terminal,
+    output: Annotated[
+        Path | None, typer.Option("--output", "-o", help="Write report to file instead of stdout.")
+    ] = None,
+    no_llm: Annotated[
+        bool,
+        typer.Option("--no-llm", help="Skip LLM analysis (security + quality stay deterministic)."),
+    ] = False,
+    yara_rules_dir: Annotated[
+        Path | None, typer.Option("--yara-rules-dir", help="Extra YARA rules directory.")
+    ] = None,
+    min_score: Annotated[
+        int | None,
+        typer.Option(
+            "--min-score",
+            help="Fail (exit 1) if the quality score is below this threshold (0-100). Off by default.",
+            min=0,
+            max=100,
+        ),
+    ] = None,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable debug logging.")] = False,
+) -> None:
+    """Scan a skill for security vulnerabilities AND rate its authoring quality."""
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, format="%(levelname)s %(name)s: %(message)s")
+    result = None
+    try:
+        state: dict[str, object] = {
+            "input_path": input_path,
+            "output_format": format.value,
+            "use_llm": not no_llm,
+        }
+        if yara_rules_dir is not None:
+            state["yara_rules_dir"] = str(yara_rules_dir.resolve())
+
+        trace_config: RunnableConfig = {"run_name": "skillspector-quality-scan"}
+        result = graph.invoke(state, config=trace_config)
+
+        report = QualityReport.from_dict(result.get("quality_report") or {"score": 0})
+        _write(_merge_output(result, format, report), output, format)
+
+        # Exit codes: preserve the upstream security risk gate first.
+        if (result.get("risk_score") or 0) > 50:
+            raise typer.Exit(code=1)
+        # Optional quality gate.
+        if min_score is not None and report.score < min_score:
+            console.print(
+                f"[red]Quality gate:[/red] score {report.score} is below --min-score {min_score}"
+            )
+            raise typer.Exit(code=1)
+    except typer.Exit:
+        raise
+    except (FileNotFoundError, ValueError) as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=2) from e
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=2) from e
+    finally:
+        if result is not None:
+            temp_dir = result.get("temp_dir_for_cleanup")
+            if (
+                temp_dir
+                and isinstance(temp_dir, str)
+                and os.path.isdir(temp_dir)
+                and os.path.abspath(temp_dir).startswith(tempfile.gettempdir())
+            ):
+                shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@app.callback()
+def main() -> None:
+    """skillspector-quality — quality rating on top of SkillSpector."""
+
+
+if __name__ == "__main__":
+    app()

--- a/src/skillspector_quality/graph.py
+++ b/src/skillspector_quality/graph.py
@@ -1,0 +1,62 @@
+"""Quality-augmented SkillSpector graph.
+
+Rebuilds the upstream pipeline by importing its nodes and analyzer registry read-only,
+and inserts a ``quality_scorer`` node that runs in parallel with the security analyzers.
+The upstream ``report`` node is reused verbatim for the security report; ``quality_report``
+simply rides along in the final state for the CLI to render.
+
+Importing ``ANALYZER_NODE_IDS`` means new upstream analyzers are picked up automatically on
+the next upstream sync — no change needed here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+from skillspector.nodes.analyzers import ANALYZER_NODE_IDS, ANALYZER_NODES
+from skillspector.nodes.build_context import build_context
+from skillspector.nodes.meta_analyzer import meta_analyzer
+from skillspector.nodes.report import report
+from skillspector.nodes.resolve_input import resolve_input
+
+from skillspector_quality.nodes.quality_scorer import quality_scorer
+from skillspector_quality.state import QualityState
+
+
+def build_graph() -> CompiledStateGraph[Any, Any, Any]:
+    """Create and compile the quality-augmented workflow graph."""
+    workflow = StateGraph(QualityState)
+
+    workflow.add_node("resolve_input", resolve_input)
+    workflow.add_node("build_context", build_context)
+    workflow.add_node("meta_analyzer", meta_analyzer)
+    workflow.add_node("report", report)
+    workflow.add_node("quality_scorer", quality_scorer)
+
+    for analyzer_id in ANALYZER_NODE_IDS:
+        workflow.add_node(analyzer_id, ANALYZER_NODES[analyzer_id])
+
+    workflow.add_edge(START, "resolve_input")
+    workflow.add_edge("resolve_input", "build_context")
+    for analyzer_id in ANALYZER_NODE_IDS:
+        workflow.add_edge("build_context", analyzer_id)
+        workflow.add_edge(analyzer_id, "meta_analyzer")
+
+    # Quality runs off the same build_context, in parallel with the analyzers, and
+    # terminates at END independently. We deliberately do NOT make `report` depend on
+    # quality_scorer: giving `report` a second predecessor in a different superstep makes
+    # LangGraph trigger it twice and double-write the `filtered_findings` channel. Keeping
+    # `report`'s single upstream (meta_analyzer) leaves the security path byte-identical to
+    # upstream; `quality_report` simply rides along in the final state.
+    workflow.add_edge("build_context", "quality_scorer")
+    workflow.add_edge("quality_scorer", END)
+
+    workflow.add_edge("meta_analyzer", "report")
+    workflow.add_edge("report", END)
+
+    return workflow.compile()
+
+
+graph = build_graph()

--- a/src/skillspector_quality/nodes/__init__.py
+++ b/src/skillspector_quality/nodes/__init__.py
@@ -1,0 +1,1 @@
+"""Graph nodes for the quality layer."""

--- a/src/skillspector_quality/nodes/quality_scorer.py
+++ b/src/skillspector_quality/nodes/quality_scorer.py
@@ -1,0 +1,37 @@
+"""quality_scorer node: computes the deterministic quality report, then (optionally)
+adds advisory LLM notes.
+
+The numeric score/grade are computed BEFORE and INDEPENDENTLY of any LLM call, so the
+result is byte-identical with or without an LLM.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from skillspector_quality.quality import score_quality
+from skillspector_quality.state import QualityState
+
+logger = logging.getLogger(__name__)
+
+# Model-config slot key, so users can override the commentary model if desired.
+ANALYZER_ID = "quality_scorer"
+
+
+def quality_scorer(state: QualityState) -> dict[str, object]:
+    """Score quality from the shared file_cache; attach LLM notes when available."""
+    file_cache: dict[str, str] = state.get("file_cache") or {}
+    report = score_quality(file_cache)
+
+    # Advisory LLM commentary — last, optional, and never affects the score.
+    if state.get("use_llm", True):
+        try:
+            from skillspector_quality.quality.commentary import add_notes
+
+            model_config: dict[str, str] = state.get("model_config") or {}
+            model = model_config.get(ANALYZER_ID) or model_config.get("default")
+            report = add_notes(report, model=model)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("quality commentary skipped: %s", exc)
+
+    return {"quality_report": report.to_dict()}

--- a/src/skillspector_quality/quality/__init__.py
+++ b/src/skillspector_quality/quality/__init__.py
@@ -1,0 +1,39 @@
+"""Deterministic quality rating engine.
+
+``score_quality`` runs every category scorer over a ``file_cache`` and returns a
+normalized 0-100 :class:`QualityReport`. No LLM is involved; the result is fully
+reproducible.
+"""
+
+from __future__ import annotations
+
+from skillspector_quality.quality.models import CategoryScore, QualityReport
+from skillspector_quality.quality.scorers import CATEGORY_SCORERS, SkillDoc
+
+__all__ = ["score_quality", "QualityReport", "CategoryScore", "SkillDoc"]
+
+
+def score_quality(file_cache: dict[str, str]) -> QualityReport:
+    """Compute the quality report for a skill from its file_cache.
+
+    Weighting is additive + normalized: each category contributes its raw ``earned``
+    out of its raw ``max``; the final score is ``round(sum(earned)/sum(max) x 100)``.
+    Adding categories therefore never breaks the 0-100 range.
+    """
+    doc = SkillDoc.from_file_cache(file_cache)
+
+    categories: list[CategoryScore] = []
+    for name, scorer in CATEGORY_SCORERS:
+        items = scorer(doc)
+        if not items:
+            continue  # N/A dimension: omit so its weight renormalizes away
+        earned = sum(e for e, _, _ in items)
+        cat_max = sum(m for _, m, _ in items)
+        categories.append(CategoryScore(name=name, earned=earned, max=cat_max, items=items))
+
+    total_earned = sum(c.earned for c in categories)
+    total_max = sum(c.max for c in categories)
+    score = round(100 * total_earned / total_max) if total_max else 0
+    score = max(0, min(100, score))
+
+    return QualityReport(score=score, categories=categories)

--- a/src/skillspector_quality/quality/commentary.py
+++ b/src/skillspector_quality/quality/commentary.py
@@ -1,0 +1,77 @@
+"""Optional LLM commentary for the quality report.
+
+This is strictly advisory: it attaches a short prose ``notes`` string to weak categories.
+It NEVER changes any numeric score. Every failure mode (no key, ``--no-llm``, network
+error, malformed response) degrades silently to "no notes".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from skillspector_quality.quality.models import QualityReport
+
+_PROMPT_HEADER = (
+    "You are reviewing the authoring quality of an AI agent 'skill'. Below are quality "
+    "categories with their earned/max points. For each category that did NOT earn full "
+    "marks, give ONE concise, concrete improvement tip (max 20 words). Return ONLY a JSON "
+    "object mapping the exact category name to its tip. No prose outside the JSON.\n\n"
+)
+
+
+def _build_prompt(report: QualityReport) -> str:
+    lines = [_PROMPT_HEADER]
+    for c in report.categories:
+        if c.earned < c.max:
+            detail = "; ".join(label for _, _, label in c.items)
+            lines.append(f"- {c.name} ({c.earned}/{c.max}): {detail}")
+    lines.append('\n\nJSON only, e.g. {"Readability": "Shorten sentences..."}')
+    return "\n".join(lines)
+
+
+def _parse_notes(raw: str) -> dict[str, str]:
+    """Best-effort extraction of a JSON object from the model response."""
+    raw = raw.strip()
+    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not match:
+        return {}
+    try:
+        data = json.loads(match.group(0))
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): str(v) for k, v in data.items() if isinstance(v, (str, int, float))}
+
+
+def add_notes(report: QualityReport, model: str | None = None) -> QualityReport:
+    """Attach advisory notes to weak categories by mutating ``report`` in-place.
+
+    Returns the same (mutated) report object. On any error the report is returned
+    unchanged (notes stay ``None``).
+    """
+    # Import here so the engine has no hard import-time dependency on LLM internals.
+    from skillspector.llm_utils import chat_completion, is_llm_available
+
+    available, _ = is_llm_available()
+    if not available:
+        return report
+
+    weak = [c for c in report.categories if c.earned < c.max]
+    if not weak:
+        return report
+
+    try:
+        raw = chat_completion(_build_prompt(report), model=model)
+    except Exception:
+        return report
+
+    notes = _parse_notes(raw)
+    if not notes:
+        return report
+
+    for c in report.categories:
+        if c.name in notes:
+            c.notes = notes[c.name]
+    return report

--- a/src/skillspector_quality/quality/models.py
+++ b/src/skillspector_quality/quality/models.py
@@ -1,0 +1,62 @@
+"""Data models for the quality rating."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class CategoryScore:
+    """Score for a single quality category.
+
+    ``items`` holds the per-sub-check breakdown as ``(earned, max, label)`` tuples,
+    mirroring the reference rater's output. ``notes`` is optional LLM commentary; it
+    never affects ``earned``/``max``.
+    """
+
+    name: str
+    earned: int
+    max: int
+    items: list[tuple[int, int, str]] = field(default_factory=list)
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "earned": self.earned,
+            "max": self.max,
+            "items": [{"earned": e, "max": m, "label": label} for e, m, label in self.items],
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class QualityReport:
+    """Aggregate quality result for one skill."""
+
+    score: int  # 0-100, normalized
+    categories: list[CategoryScore] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "score": self.score,
+            "categories": [c.to_dict() for c in self.categories],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QualityReport:
+        """Rebuild a QualityReport from its serialized dict (graph state round-trip)."""
+        cats: list[CategoryScore] = []
+        for c in data.get("categories", []) or []:
+            items = [(it["earned"], it["max"], it["label"]) for it in c.get("items", []) or []]
+            cats.append(
+                CategoryScore(
+                    name=c["name"],
+                    earned=c["earned"],
+                    max=c["max"],
+                    items=items,
+                    notes=c.get("notes"),
+                )
+            )
+        return cls(score=int(data["score"]), categories=cats)

--- a/src/skillspector_quality/quality/render.py
+++ b/src/skillspector_quality/quality/render.py
@@ -1,0 +1,219 @@
+"""Render the quality report for each output format.
+
+Kept separate from the upstream report node so SkillSpector's own formatters stay
+untouched; the CLI stitches these in.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from io import StringIO
+from typing import Any
+
+import skillspector
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from skillspector_quality.quality.models import QualityReport
+
+_SKILLSPECTOR_VERSION = getattr(skillspector, "__version__", "")
+
+_SEV_COLOR: dict[str, str] = {
+    "CRITICAL": "red",
+    "HIGH": "red",
+    "FAIR": "yellow",
+    "GOOD": "green",
+    "EXCELLENT": "green",
+    "MEDIUM": "yellow",
+    "LOW": "green",
+}
+
+# Quality score thresholds → (severity label, recommendation).
+# Mirrors SkillSpector's risk_severity / risk_recommendation pattern.
+_QUALITY_LEVELS: list[tuple[int, str, str]] = [
+    (85, "EXCELLENT", "READY TO PUBLISH"),
+    (70, "GOOD", "REVIEW RECOMMENDED"),
+    (55, "FAIR", "IMPROVE BEFORE PUBLISHING"),
+    (40, "POOR", "SIGNIFICANT WORK NEEDED"),
+    (0, "CRITICAL", "NOT READY"),
+]
+
+
+def _quality_status(score: int) -> tuple[str, str]:
+    """Return (severity, recommendation) for a 0-100 quality score."""
+    for threshold, severity, recommendation in _QUALITY_LEVELS:
+        if score >= threshold:
+            return severity, recommendation
+    return "CRITICAL", "NOT READY"
+
+
+def _score_color(score: int) -> str:
+    if score >= 70:
+        return "green"
+    if score >= 40:
+        return "yellow"
+    return "red"
+
+
+# --------------------------------------------------------------------------- #
+# Unified terminal renderer (security + quality in one report)                #
+# --------------------------------------------------------------------------- #
+
+
+def unified_terminal_text(result: dict[str, Any], report: QualityReport) -> str:
+    """Single cohesive terminal report combining security and quality sections.
+
+    Builds from raw graph state (manifest, component_metadata, filtered_findings,
+    risk_score / risk_severity / risk_recommendation) so both halves share one
+    header, one component table, and a side-by-side overview.
+    """
+    console = Console(record=True, force_terminal=True, width=88, file=StringIO())
+
+    manifest: dict[str, Any] = result.get("manifest") or {}
+    skill_name: str = manifest.get("name") or "unknown"
+    skill_path: str = result.get("skill_path") or result.get("input_path") or ""
+    scanned: str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    risk_score: int = result.get("risk_score") or 0
+    risk_severity: str = (result.get("risk_severity") or "UNKNOWN").upper()
+    risk_rec: str = result.get("risk_recommendation") or ""
+    findings: list[Any] = result.get("filtered_findings") or []
+    components: list[Any] = result.get("component_metadata") or []
+
+    version_sub = f"v{_SKILLSPECTOR_VERSION}" if _SKILLSPECTOR_VERSION else ""
+
+    # ── Header ──────────────────────────────────────────────────────────────
+    console.print(
+        Panel(
+            f"[bold]Skill:[/bold] {skill_name}\n"
+            f"[bold]Source:[/bold] {skill_path}\n"
+            f"[bold]Scanned:[/bold] {scanned}",
+            title="SkillSpector Report",
+            subtitle=version_sub,
+        )
+    )
+
+    # ── Overview: security + quality side by side ────────────────────────────
+    # Both columns are risk scores: 0 = best, 100 = worst.
+    # Quality risk = 100 - quality score so the direction matches security.
+    sev_color = _SEV_COLOR.get(risk_severity, "white")
+    quality_risk = 100 - report.score
+    qual_color = _score_color(report.score)
+    qual_severity, qual_rec = _quality_status(report.score)
+
+    overview = Table(
+        show_header=True,
+        box=box.SIMPLE_HEAD,
+        title="Overview",
+        caption="Risk Score: 0 = best  ·  100 = worst",
+    )
+    overview.add_column("Dimension", style="bold")
+    overview.add_column("Risk Score", justify="right")
+    overview.add_column("Status")
+    overview.add_row(
+        "Security",
+        f"[{sev_color}]{risk_score}/100[/{sev_color}]",
+        f"[{sev_color}]{risk_severity}  {risk_rec}[/{sev_color}]",
+    )
+    overview.add_row(
+        "Quality",
+        f"[{qual_color}]{quality_risk}/100[/{qual_color}]",
+        f"[{qual_color}]{qual_severity}  {qual_rec}[/{qual_color}]",
+    )
+    console.print(overview)
+
+    # ── Components ───────────────────────────────────────────────────────────
+    if components:
+        ct = Table(
+            title=f"Components ({len(components)})",
+            show_header=True,
+            box=box.SIMPLE_HEAD,
+        )
+        ct.add_column("File")
+        ct.add_column("Type")
+        ct.add_column("Lines", justify="right")
+        ct.add_column("Executable")
+        for comp in components:
+            ct.add_row(
+                comp.get("path", ""),
+                comp.get("type", ""),
+                str(comp.get("lines", "")),
+                "[yellow]Yes[/yellow]" if comp.get("executable") else "No",
+            )
+        console.print(ct)
+
+    # ── Security Issues ──────────────────────────────────────────────────────
+    console.print(f"\n[bold]Security Issues ({len(findings)})[/bold]")
+    if not findings:
+        console.print("  [green]No security issues detected.[/green]\n")
+    else:
+        for f in findings:
+            sev = (getattr(f, "severity", "") or "").upper()
+            fc = _SEV_COLOR.get(sev, "white")
+            loc = f"{getattr(f, 'file', '')}:{getattr(f, 'start_line', '')}"
+            pct = int((getattr(f, "confidence", 0) or 0) * 100)
+            console.print(
+                f"\n  [{fc}]{sev}[/{fc}] [{getattr(f, 'rule_id', '')}]  "
+                f"{getattr(f, 'message', '')}",
+                highlight=False,
+            )
+            console.print(f"    [dim]Location: {loc}  |  Confidence: {pct}%[/dim]")
+            rem = getattr(f, "remediation", "") or ""
+            if rem:
+                console.print(f"    [dim]Remediation: {rem.strip()[:120]}[/dim]")
+
+    # ── Quality Dimensions ───────────────────────────────────────────────────
+    console.print("\n[bold]Quality Dimensions[/bold]")
+    for c in report.categories:
+        mark = (
+            "[green]+[/green]"
+            if c.earned == c.max
+            else ("[yellow]~[/yellow]" if c.earned > 0 else "[red]x[/red]")
+        )
+        console.print(f"  {mark} {c.earned:>2}/{c.max:<2}  {c.name}")
+        for _, _, label in c.items:
+            console.print(f"      [dim]{label}[/dim]")
+        if c.notes:
+            console.print(f"      [cyan]tip:[/cyan] {c.notes}")
+
+    return console.export_text()
+
+
+# --------------------------------------------------------------------------- #
+# Non-terminal formats (unchanged structure)                                  #
+# --------------------------------------------------------------------------- #
+
+
+def quality_markdown_section(report: QualityReport) -> str:
+    """Markdown '## Quality Assessment' section appended to the security report."""
+    lines: list[str] = []
+    lines.append("\n## Quality Assessment\n")
+    lines.append(f"**Score:** {report.score}/100  ")
+    lines.append("")
+    lines.append("| Category | Score |")
+    lines.append("|----------|-------|")
+    for c in report.categories:
+        lines.append(f"| {c.name} | {c.earned}/{c.max} |")
+    lines.append("")
+    notes = [(c.name, c.notes) for c in report.categories if c.notes]
+    if notes:
+        lines.append("### Suggestions\n")
+        for name, note in notes:
+            lines.append(f"- **{name}:** {note}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def quality_json_dict(report: QualityReport) -> dict[str, object]:
+    """JSON 'quality_assessment' object (sibling of risk_assessment)."""
+    return report.to_dict()
+
+
+def quality_sarif_properties(report: QualityReport) -> dict[str, object]:
+    """Compact summary for SARIF runs[0].properties.quality (not a result)."""
+    return {
+        "score": report.score,
+        "categories": {c.name: {"earned": c.earned, "max": c.max} for c in report.categories},
+    }

--- a/src/skillspector_quality/quality/scorers.py
+++ b/src/skillspector_quality/quality/scorers.py
@@ -1,0 +1,1078 @@
+"""Deterministic, math-grounded quality scorers.
+
+Nine dimensions evaluate the whole skill bundle (SKILL.md + markdown docs + scripts) using
+information theory, length-invariant lexical statistics, a readability ensemble, TF-IDF
+vector-space topic modeling, link-graph structure, and code-maintainability metrics.
+
+Design principles:
+
+* **Length-neutral.** Every content metric is a ratio or a length-invariant statistic, so
+  more *good* content is never penalized; redundancy and low information density are.
+* **N/A => weight renormalization.** A dimension that does not apply (e.g. no scripts)
+  returns ``[]`` and is omitted by the engine, leaving both numerator and denominator — it
+  neither rewards nor punishes.
+* **Pure & deterministic.** No LLM, no randomness. ``radon`` is used for code metrics; the
+  rest is stdlib (``zlib``, ``math``, ``ast``) plus hand-rolled TF-IDF / MTLD / readability.
+
+Each dimension takes a :class:`SkillDoc` and returns ``list[(earned, max, label)]`` where
+``max`` is the dimension weight and ``earned = round(weight * s)`` with ``s in [0, 1]``.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import math
+import re
+import zlib
+from collections import Counter
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - dependency declared in pyproject
+    raise ImportError("pyyaml is required (pip install pyyaml)") from exc
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+# Valid values for enum-typed behavioral-config fields (spec-defined).
+_VALID_EFFORT: frozenset[str] = frozenset({"low", "medium", "high", "xhigh", "max"})
+_VALID_SHELL: frozenset[str] = frozenset({"bash", "powershell"})
+_VALID_CONTEXT: frozenset[str] = frozenset({"fork"})
+
+# All 13 behavioral/execution/lifecycle frontmatter fields from the spec.
+_BEHAVIORAL_FIELDS: frozenset[str] = frozenset(
+    {
+        "paths",
+        "user-invocable",
+        "arguments",
+        "argument-hint",
+        "allowed-tools",
+        "disallowed-tools",
+        "disable-model-invocation",
+        "model",
+        "effort",
+        "context",
+        "agent",
+        "shell",
+        "hooks",
+    }
+)
+
+STOPWORDS = {
+    "this",
+    "that",
+    "with",
+    "from",
+    "into",
+    "when",
+    "used",
+    "uses",
+    "for",
+    "and",
+    "the",
+    "are",
+    "your",
+    "have",
+    "will",
+    "about",
+    "also",
+    "been",
+    "each",
+    "they",
+    "them",
+    "then",
+    "their",
+    "than",
+    "more",
+    "some",
+    "such",
+    "just",
+    "very",
+    "well",
+    "both",
+}
+
+_TRIGGER_VERBS_RE = re.compile(r"\b(use|invoke|trigger|call|apply|run|activate)\b", re.IGNORECASE)
+_NEGATION_RE = re.compile(
+    r"\b(do[\s-]not|don't|never|skip|avoid|not for|except when|only when)\b", re.IGNORECASE
+)
+_CONDITIONAL_RE = re.compile(r"\b(when|if|while|after|before)\b", re.IGNORECASE)
+
+FENCE_RE = re.compile(r"^\s*```([A-Za-z0-9_+-]*)\s*$")
+LINK_RE = re.compile(r"\[.*?\]\(([^)]+)\)")
+SCRIPT_PATH_RE = re.compile(r"(?<![\w/])((?:scripts|assets|references|reference)/[\w./-]+)")
+HEADING_RE = re.compile(r"^(#{1,6})\s+\S")
+STRUCTURED_LINE_RE = re.compile(r"^\s*([-*+] |\d+[.)]\s)")
+
+MARKDOWN_EXTS = {".md", ".markdown"}
+SCRIPT_EXTS = {".py", ".sh", ".bash", ".zsh", ".js", ".ts", ".rb", ".go", ".rs", ".pl"}
+SHELL_EXTS = {".sh", ".bash", ".zsh"}
+
+
+def clamp01(x: float) -> float:
+    return max(0.0, min(1.0, x))
+
+
+def _when_specificity(when: str) -> float:
+    """Score 0..1 for how actionable a when_to_use value is.
+
+    Based on the AGENTbench finding (Gloaguen et al., 2026) that minimal, specific
+    trigger + exclusion conditions are the highest-ROI content in agent context files,
+    while vague prose duplicating the description yields cost with no benefit.
+    """
+    s = 0.0
+    if len(when) >= 15:
+        s += 0.30  # has something substantive
+    if _TRIGGER_VERBS_RE.search(when):
+        s += 0.25  # concrete trigger verb ("Use when...", "Invoke for...")
+    if _NEGATION_RE.search(when):
+        s += 0.25  # exclusion condition — highest-ROI signal per research
+    if _CONDITIONAL_RE.search(when) and len(when) > 30:
+        s += 0.10  # conditional context ("when X", "if Y")
+    if len(when) > 80:
+        s += 0.10  # enough detail to cover multiple cases
+    return clamp01(s)
+
+
+def _ext(path: str) -> str:
+    idx = path.rfind(".")
+    return path[idx:].lower() if idx >= 0 else ""
+
+
+# --------------------------------------------------------------------------- #
+# Parsed-skill container
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class SkillDoc:
+    """Everything the dimensions need, parsed once from the file_cache."""
+
+    file_cache: dict[str, str]
+    data: dict[str, Any]  # SKILL.md frontmatter
+    body: str  # SKILL.md body (after frontmatter)
+    body_lines: list[str]
+    body_lower: str
+    skill_md_key: str  # actual key used for SKILL.md
+    markdown_docs: dict[str, str] = field(default_factory=dict)  # non-SKILL.md markdown
+    scripts: dict[str, str] = field(default_factory=dict)  # code files
+
+    @classmethod
+    def from_file_cache(cls, file_cache: dict[str, str]) -> SkillDoc:
+        skill_key = (
+            "SKILL.md"
+            if "SKILL.md" in file_cache
+            else ("skill.md" if "skill.md" in file_cache else "SKILL.md")
+        )
+        text = file_cache.get(skill_key, "")
+        data = _parse_frontmatter(text)
+        body = _body(text)
+
+        markdown_docs: dict[str, str] = {}
+        scripts: dict[str, str] = {}
+        for path, content in file_cache.items():
+            if path in ("SKILL.md", "skill.md"):
+                continue
+            ext = _ext(path)
+            if ext in MARKDOWN_EXTS:
+                markdown_docs[path] = content
+            elif ext in SCRIPT_EXTS:
+                scripts[path] = content
+
+        return cls(
+            file_cache=file_cache,
+            data=data if isinstance(data, dict) else {},
+            body=body,
+            body_lines=body.splitlines(),
+            body_lower=body.lower(),
+            skill_md_key=skill_key,
+            markdown_docs=markdown_docs,
+            scripts=scripts,
+        )
+
+    @functools.cached_property
+    def all_prose(self) -> str:
+        """Concatenated prose (code fences stripped) of SKILL.md body + markdown docs."""
+        parts = [_strip_fences_text(self.body)]
+        for content in self.markdown_docs.values():
+            parts.append(_strip_fences_text(content))
+        return "\n".join(parts)
+
+
+def _parse_frontmatter(text: str) -> dict[str, Any]:
+    text = text.replace("\r\n", "\n")
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    try:
+        data = yaml.safe_load(text[3:end].strip())
+        return data if isinstance(data, dict) else {}
+    except yaml.YAMLError:
+        return {}
+
+
+def _body(text: str) -> str:
+    text = text.replace("\r\n", "\n")
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        # Unclosed frontmatter: skip the opening --- line to avoid YAML in prose metrics.
+        nl = text.find("\n")
+        return text[nl + 1 :].lstrip("\n") if nl != -1 else ""
+    return text[end + 4 :].lstrip("\n")
+
+
+# --------------------------------------------------------------------------- #
+# Generic text helpers
+# --------------------------------------------------------------------------- #
+
+
+def _strip_code_fences(lines: list[str]) -> list[str]:
+    """Return lines outside fenced code blocks."""
+    out: list[str] = []
+    in_fence = False
+    for ln in lines:
+        if FENCE_RE.match(ln):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(ln)
+    return out
+
+
+def _strip_fences_text(text: str) -> str:
+    return "\n".join(_strip_code_fences(text.splitlines()))
+
+
+def _word_tokens(text: str) -> list[str]:
+    """All lowercase word tokens (apostrophes kept)."""
+    return re.findall(r"[a-z][a-z']*", text.lower())
+
+
+def _terms(text: str) -> list[str]:
+    """Content terms for topic modeling: lowercase, >=3 chars, stopwords removed."""
+    return [w for w in re.findall(r"[a-z]{3,}", text.lower()) if w not in STOPWORDS]
+
+
+def _count_syllables(word: str) -> int:
+    """Cheap syllable estimate: count vowel groups, min 1."""
+    groups = re.findall(r"[aeiouy]+", word.lower())
+    n = len(groups)
+    if word.lower().endswith("e") and n > 1:
+        n -= 1
+    return max(1, n)
+
+
+# --------------------------------------------------------------------------- #
+# Information-theory helpers
+# --------------------------------------------------------------------------- #
+
+
+def _compression_ratio(text: str) -> float:
+    """len(compressed) / len(raw) in bytes. Higher => denser / less redundant."""
+    raw = text.encode("utf-8", errors="replace")
+    if not raw:
+        return 0.0
+    comp = zlib.compress(raw, 1)
+    return len(comp) / len(raw)
+
+
+def _ngram_dup(tokens: list[str], n: int = 5) -> float:
+    """Fraction of n-gram shingles that are repeats (0 = no duplication)."""
+    if len(tokens) < n:
+        return 0.0
+    shingles = [tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)]
+    total = len(shingles)
+    unique = len(set(shingles))
+    return 1.0 - unique / total
+
+
+# --------------------------------------------------------------------------- #
+# Lexical-diversity helpers (length-invariant)
+# --------------------------------------------------------------------------- #
+
+
+def _mtld_one_pass(tokens: list[str], threshold: float) -> float:
+    factors = 0.0
+    types: set[str] = set()
+    count = 0
+    for t in tokens:
+        count += 1
+        types.add(t)
+        if len(types) / count <= threshold:
+            factors += 1
+            types = set()
+            count = 0
+    if count > 0:
+        ttr = len(types) / count
+        factors += (1 - ttr) / (1 - threshold)
+    if factors == 0:
+        return float(len(tokens))
+    return len(tokens) / factors
+
+
+def _mtld(tokens: list[str], threshold: float = 0.72) -> float:
+    """Measure of Textual Lexical Diversity (bidirectional mean). Length-invariant."""
+    if not tokens:
+        return 0.0
+    fwd = _mtld_one_pass(tokens, threshold)
+    bwd = _mtld_one_pass(list(reversed(tokens)), threshold)
+    return (fwd + bwd) / 2
+
+
+def _hdd(tokens: list[str], sample_size: int = 42) -> float | None:
+    """HD-D: mean per-type probability of appearing in a random sample. None if too short."""
+    n = len(tokens)
+    if n < sample_size:
+        return None
+    freq = Counter(tokens)
+    denom = math.comb(n, sample_size)
+    hdd = 0.0
+    for cnt in freq.values():
+        # P(type appears at least once in a sample of sample_size)
+        p_absent = math.comb(n - cnt, sample_size) / denom if n - cnt >= sample_size else 0.0
+        hdd += (1 - p_absent) * (1 / sample_size)
+    return hdd
+
+
+# --------------------------------------------------------------------------- #
+# Readability helpers (ensemble)
+# --------------------------------------------------------------------------- #
+
+
+def _prose_for_readability(doc: SkillDoc) -> str:
+    lines = [
+        ln
+        for ln in _strip_code_fences(doc.body_lines)
+        if ln.strip()
+        and not ln.lstrip().startswith(("#", "|", ">"))
+        and not STRUCTURED_LINE_RE.match(ln)
+    ]
+    for content in doc.markdown_docs.values():
+        for ln in _strip_code_fences(content.splitlines()):
+            s = ln.strip()
+            if (
+                s
+                and not ln.lstrip().startswith(("#", "|", ">"))
+                and not STRUCTURED_LINE_RE.match(ln)
+            ):
+                lines.append(ln)
+    return " ".join(lines)
+
+
+def _readability_grades(text: str) -> tuple[list[float], int]:
+    """Return (list of 5 grade levels, word count). Empty list if too little prose."""
+    words = re.findall(r"[A-Za-z]+", text)
+    sentences = [s for s in re.split(r"[.!?]+", text) if s.strip()]
+    w = len(words)
+    s = max(1, len(sentences))
+    if w < 30:
+        return [], w
+
+    syll = [_count_syllables(x) for x in words]
+    total_syll = sum(syll)
+    complex_words = sum(1 for c in syll if c >= 3)
+    letters = sum(len(x) for x in words)
+
+    wps = w / s  # words per sentence
+    spw = total_syll / w  # syllables per word
+
+    fk = 0.39 * wps + 11.8 * spw - 15.59
+    fog = 0.4 * (wps + 100 * complex_words / w)
+    smog = 1.0430 * math.sqrt(complex_words * (30 / s)) + 3.1291
+    ari = 4.71 * (letters / w) + 0.5 * wps - 21.43
+    cl = 0.0588 * (letters / w * 100) - 0.296 * (s / w * 100) - 15.8
+
+    return [fk, fog, smog, ari, cl], w
+
+
+def _median(xs: list[float]) -> float:
+    ys = sorted(xs)
+    n = len(ys)
+    mid = n // 2
+    return ys[mid] if n % 2 else (ys[mid - 1] + ys[mid]) / 2
+
+
+# --------------------------------------------------------------------------- #
+# TF-IDF helpers (vector space)
+# --------------------------------------------------------------------------- #
+
+
+def _tf(terms: list[str]) -> dict[str, float]:
+    if not terms:
+        return {}
+    c = Counter(terms)
+    total = len(terms)
+    return {t: n / total for t, n in c.items()}
+
+
+def _build_idf(corpus_terms: list[list[str]]) -> dict[str, float]:
+    n = len(corpus_terms)
+    df: Counter[str] = Counter()
+    for terms in corpus_terms:
+        for t in set(terms):
+            df[t] += 1
+    return {t: math.log((1 + n) / (1 + d)) + 1 for t, d in df.items()}
+
+
+def _tfidf_vec(terms: list[str], idf: dict[str, float]) -> dict[str, float]:
+    vec = {t: tf * idf.get(t, 0.0) for t, tf in _tf(terms).items()}
+    norm = math.sqrt(sum(v * v for v in vec.values()))
+    if norm == 0:
+        return {}
+    return {t: v / norm for t, v in vec.items()}
+
+
+def _cosine(a: dict[str, float], b: dict[str, float]) -> float:
+    if not a or not b:
+        return 0.0
+    small, big = (a, b) if len(a) < len(b) else (b, a)
+    return sum(v * big.get(t, 0.0) for t, v in small.items())
+
+
+# --------------------------------------------------------------------------- #
+# Structure helpers (graph + heading tree)
+# --------------------------------------------------------------------------- #
+
+
+def _heading_levels(text: str) -> list[int]:
+    levels: list[int] = []
+    for ln in _strip_code_fences(text.splitlines()):
+        m = HEADING_RE.match(ln)
+        if m:
+            levels.append(len(m.group(1)))
+    return levels
+
+
+def _relative_targets(text: str) -> list[str]:
+    out: list[str] = []
+    for t in LINK_RE.findall(text):
+        out.append(t)
+    out.extend(SCRIPT_PATH_RE.findall(text))
+    cleaned: list[str] = []
+    for t in out:
+        t = t.strip()
+        if not t or re.match(r"^(https?://|mailto:|#|//)", t):
+            continue
+        t = t.split("#", 1)[0].split("?", 1)[0]
+        if t.startswith("./"):
+            t = t[2:]
+        if t:
+            cleaned.append(t)
+    return cleaned
+
+
+def _resolve_target(target: str, keys: set[str]) -> str | None:
+    if target in keys:
+        return target
+    if target.endswith("/"):
+        for k in keys:
+            if k.startswith(target):
+                return k
+        return None
+    for k in keys:
+        if k == target or k.endswith("/" + target):
+            return k
+    return None
+
+
+def _link_graph(doc: SkillDoc) -> tuple[dict[str, set[str]], set[str]]:
+    """Return (adjacency, nodes). Edges = resolved relative refs from each markdown file."""
+    keys = set(doc.file_cache.keys())
+    adj: dict[str, set[str]] = {k: set() for k in keys}
+    md_files = {doc.skill_md_key: doc.body, **doc.markdown_docs}
+    for src, content in md_files.items():
+        for tgt in _relative_targets(content):
+            resolved = _resolve_target(tgt, keys)
+            if resolved and resolved != src:
+                adj[src].add(resolved)
+    return adj, keys
+
+
+def _reachable_from(adj: dict[str, set[str]], root: str) -> set[str]:
+    seen: set[str] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(adj.get(node, ()))
+    return seen
+
+
+def _is_acyclic(adj: dict[str, set[str]]) -> bool:
+    WHITE, GRAY, BLACK = 0, 1, 2  # noqa: N806
+    color: dict[str, int] = dict.fromkeys(adj, WHITE)
+
+    for start in adj:
+        if color[start] != WHITE:
+            continue
+        stack: list[tuple[str, Iterator[str]]] = [(start, iter(adj.get(start, ())))]
+        color[start] = GRAY
+        while stack:
+            node, neighbors = stack[-1]
+            try:
+                m = next(neighbors)
+                c = color.get(m, WHITE)
+                if c == GRAY:
+                    return False
+                if c == WHITE:
+                    color[m] = GRAY
+                    stack.append((m, iter(adj.get(m, ()))))
+            except StopIteration:
+                color[node] = BLACK
+                stack.pop()
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Code-maintainability helpers (radon + ast)
+# --------------------------------------------------------------------------- #
+
+
+def _python_maintainability(code: str) -> tuple[float, dict[str, Any]]:
+    """Return (s in [0,1], metrics) for one Python script."""
+    try:
+        from radon.complexity import cc_visit
+        from radon.metrics import mi_visit
+    except ImportError:
+        return 0.5, {"error": "radon not installed (pip install skillspector-quality[code])"}
+
+    metrics: dict[str, Any] = {}
+    # Maintainability Index (0-100).
+    try:
+        mi = mi_visit(code, multi=True)
+    except (SyntaxError, Exception):  # noqa: BLE001 - radon may raise various errors
+        return 0.0, {"error": "unparseable"}
+    metrics["mi"] = round(mi, 1)
+    mi_norm = clamp01(mi / 100)
+
+    # Average cyclomatic complexity.
+    try:
+        blocks = cc_visit(code)
+        avg_cc = sum(b.complexity for b in blocks) / len(blocks) if blocks else 1.0
+    except (SyntaxError, Exception):  # noqa: BLE001
+        blocks = []
+        avg_cc = 1.0
+    metrics["avg_cc"] = round(avg_cc, 1)
+    cc_norm = clamp01((15 - avg_cc) / 14)
+
+    # Docstring coverage via ast.
+    try:
+        tree = ast.parse(code)
+        units = 1  # module
+        documented = 1 if ast.get_docstring(tree) else 0
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                units += 1
+                if ast.get_docstring(node):
+                    documented += 1
+        dc = documented / units
+    except SyntaxError:
+        dc = 0.0
+    metrics["docstring_cov"] = round(dc, 2)
+
+    # Comment density.
+    lines = code.splitlines()
+    comment_lines = sum(
+        1 for ln in lines if ln.lstrip().startswith("#") and not ln.lstrip().startswith("#!")
+    )
+    code_lines = sum(1 for ln in lines if ln.strip() and not ln.lstrip().startswith("#"))
+    cd = comment_lines / code_lines if code_lines else 0.0
+    cd_norm = clamp01(cd / 0.10)
+    metrics["comment_density"] = round(cd, 2)
+
+    s = 0.40 * mi_norm + 0.25 * cc_norm + 0.20 * dc + 0.15 * cd_norm
+    return s, metrics
+
+
+def _other_script_quality(path: str, code: str) -> float:
+    lines = code.splitlines()
+    nonblank = [ln for ln in lines if ln.strip()]
+    if not nonblank:
+        return 0.0
+    signals: list[float] = []
+    if _ext(path) in SHELL_EXTS:
+        signals.append(1.0 if lines and lines[0].startswith("#!") else 0.0)
+    first = nonblank[0].lstrip()
+    signals.append(1.0 if first.startswith(("#", "//", "/*", "--")) else 0.0)
+    comment_lines = sum(
+        1
+        for ln in lines
+        if ln.lstrip().startswith(("#", "//", "--")) and not ln.lstrip().startswith("#!")
+    )
+    code_lines = max(1, len(nonblank) - comment_lines)
+    signals.append(clamp01((comment_lines / code_lines) / 0.10))
+    signals.append(1.0 if 1 <= len(nonblank) <= 500 else 0.5)
+    return sum(signals) / len(signals)
+
+
+# --------------------------------------------------------------------------- #
+# Dimensions (each: (name, weight, scorer))
+# --------------------------------------------------------------------------- #
+
+
+def dim_metadata(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    data = doc.data
+    desc = data.get("description") or ""
+    when = data.get("when_to_use") or ""
+    _meta_raw = data.get("metadata")
+    meta: dict[str, Any] = _meta_raw if isinstance(_meta_raw, dict) else {}
+    name = str(data.get("name") or "")
+    # Only name and description are required by the official spec.
+    # when_to_use, author, version are optional: 0.5 (neutral) when absent.
+    when_spec = _when_specificity(when) if when else 0.0
+    signals = [
+        1.0 if 0 < len(desc) <= 1024 else (0.5 if desc else 0.0),  # required
+        when_spec if when else 0.5,  # optional: neutral if absent, specificity-scored if set
+        1.0 if meta.get("author") else 0.5,  # optional: neutral if absent
+        1.0 if meta.get("version") else 0.5,  # optional: neutral if absent
+        1.0 if re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", name) else 0.0,  # required
+    ]
+    s = sum(signals) / len(signals)
+    missing_required = []
+    if not desc:
+        missing_required.append("description")
+    if not signals[4]:
+        missing_required.append("name (kebab-case format required)")
+    optional_improvements = []
+    if not when:
+        optional_improvements.append("when_to_use")
+    elif when_spec < 0.7:
+        optional_improvements.append(
+            "when_to_use specificity — add trigger conditions and 'Do not use for X' exclusions"
+        )
+    if not meta.get("author"):
+        optional_improvements.append("author")
+    if not meta.get("version"):
+        optional_improvements.append("version")
+    if missing_required:
+        label = f"Required fields missing: {', '.join(missing_required)}"
+        if optional_improvements:
+            label += f" — also consider: {', '.join(optional_improvements)}"
+    elif optional_improvements:
+        label = f"Required fields present; consider: {', '.join(optional_improvements)} (improves agent ROI)"
+    else:
+        label = "All fields complete"
+    return [(round(w * s), w, label)]
+
+
+def dim_information_density(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    prose = doc.all_prose
+    if not prose.strip():
+        return [(0, w, "no prose to assess")]
+    r = _compression_ratio(prose)
+    density = clamp01((r - 0.30) / (0.55 - 0.30))
+    dup = _ngram_dup(_word_tokens(prose), n=5)
+    s = 0.6 * density + 0.4 * (1 - dup)
+    if dup > 0.3:
+        label = f"Repeated phrases make up {dup:.0%} of content — reduce copy-paste text"
+    elif density < 0.4:
+        label = "Content is thin — add more concrete, specific detail"
+    else:
+        label = "Content is dense and non-repetitive"
+    return [(round(w * s), w, label)]
+
+
+def dim_lexical_diversity(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    tokens = _word_tokens(doc.all_prose)
+    if len(tokens) < 50:
+        return []  # N/A: too little text to measure reliably
+    mtld = _mtld(tokens)
+    s = clamp01((mtld - 30) / (100 - 30))
+    if s >= 0.7:
+        label = f"Vocabulary is rich and varied ({len(tokens)} words)"
+    elif s >= 0.4:
+        label = f"Vocabulary is adequate but somewhat repetitive ({len(tokens)} words)"
+    else:
+        label = f"Vocabulary is repetitive — try using more varied language ({len(tokens)} words)"
+    return [(round(w * s), w, label)]
+
+
+def dim_readability(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    grades, words = _readability_grades(_prose_for_readability(doc))
+    if not grades:
+        return []  # N/A: <30 words of prose
+    g = _median(grades)
+    if 8 <= g <= 14:
+        s = 1.0
+    elif g < 8:
+        s = clamp01((g - 3) / 5)
+    else:
+        s = clamp01((22 - g) / 8)
+    g_int = round(g)
+    if 8 <= g <= 14:
+        label = f"Reading level: {g_int}th grade — good for technical documentation"
+    elif g < 8:
+        label = f"Writing is too simple ({g_int}th grade) — add more technical depth"
+    else:
+        label = f"Writing is too complex ({g_int}th grade) — simplify for broader audiences"
+    return [(round(w * s), w, label)]
+
+
+def dim_topic_coverage(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    desc = doc.data.get("description") or ""
+    body_terms = _terms(doc.body)
+    if not body_terms:
+        return [(0, w, "empty body")]
+
+    corpus_terms = [body_terms] + [_terms(c) for c in doc.markdown_docs.values()]
+    idf = _build_idf(corpus_terms)
+
+    body_vec = _tfidf_vec(body_terms, idf)
+    desc_vec = _tfidf_vec(_terms(desc), idf)
+    coverage = _cosine(desc_vec, body_vec) if desc else 0.0
+
+    # Calibration: in TF-IDF space a cosine of ~0.5 already signals strong topical
+    # alignment between a terse description and a full body, so treat 0.5 as full credit.
+    ref = 0.5
+    cov_norm = clamp01(coverage / ref)
+
+    if doc.markdown_docs:
+        cohesions = [
+            _cosine(body_vec, _tfidf_vec(_terms(c), idf)) for c in doc.markdown_docs.values()
+        ]
+        cohesion = sum(cohesions) / len(cohesions)
+        s = 0.5 * cov_norm + 0.5 * clamp01(cohesion / ref)
+        if s >= 0.9:
+            label = "Description aligns well with skill content and supporting docs"
+        elif coverage < 0.25:
+            label = "Description doesn't match the skill body — rewrite it to reflect what the skill actually does"
+        else:
+            label = "Description partially matches skill content — refine it to better reflect actual functionality"
+    else:
+        s = cov_norm
+        if cov_norm >= 0.9:
+            label = "Description aligns well with skill content"
+        elif coverage < 0.25:
+            label = "Description doesn't match the skill body — rewrite it to reflect what the skill actually does"
+        else:
+            label = "Description partially matches skill content — refine it to better reflect actual functionality"
+    return [(round(w * s), w, label)]
+
+
+def dim_structural_coherence(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    levels = _heading_levels(doc.body)
+    if len(levels) <= 1:
+        s_head = 1.0 if levels == [1] else 0.5
+        skips = 0
+    else:
+        skips = sum(1 for a, b in zip(levels, levels[1:], strict=False) if b - a > 1)
+        transitions = len(levels) - 1
+        s_head = 1 - skips / transitions
+    h1_count = sum(1 for lv in levels if lv == 1)
+    if h1_count != 1:
+        s_head *= 0.5
+
+    adj, nodes = _link_graph(doc)
+    if len(nodes) <= 1:
+        reach = 1.0
+    else:
+        reachable = _reachable_from(adj, doc.skill_md_key)
+        reach = len(reachable) / len(nodes)
+    acyclic = 1.0 if _is_acyclic(adj) else 0.0
+
+    s = 0.5 * s_head + 0.4 * reach + 0.1 * acyclic
+    parts: list[str] = []
+    if skips > 0:
+        parts.append(f"{skips} heading level skip(s) — avoid jumping over heading levels")
+    else:
+        parts.append("heading structure is correct")
+    if reach < 1.0:
+        unreachable = max(1, round(len(nodes) * (1 - reach)))
+        parts.append(f"{unreachable} file(s) not linked from SKILL.md — add links to connect them")
+    else:
+        parts.append("all files are linked")
+    if not acyclic:
+        parts.append("circular links detected — fix link loops")
+    label = "; ".join(parts)
+    return [(round(w * s), w, label)]
+
+
+def dim_code_maintainability(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    if not doc.scripts:
+        return []  # N/A: omit, weights renormalize
+    scores: list[float] = []
+    py_detail = ""
+    for path, code in sorted(doc.scripts.items()):
+        if _ext(path) == ".py":
+            s, m = _python_maintainability(code)
+            if not py_detail and "mi" in m:
+                py_detail = f" e.g. {path}: MI={m['mi']}, CC={m['avg_cc']}, docstrings={m['docstring_cov']:.0%}"
+        else:
+            s = _other_script_quality(path, code)
+        scores.append(s)
+    s = sum(scores) / len(scores)
+    if s >= 0.8:
+        label = f"{len(scores)} script(s) — code is clean and well-documented"
+    elif s >= 0.5:
+        label = f"{len(scores)} script(s) — code needs more documentation or has complex functions"
+    else:
+        label = f"{len(scores)} script(s) — code is hard to maintain; add docstrings and reduce complexity"
+    return [(round(w * s), w, label)]
+
+
+def dim_example_quality(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    source = doc.file_cache.get("examples.md") or doc.body
+    sections = re.split(r"^#{2,3}\s+Example", source, flags=re.MULTILINE)[1:]
+    if not sections:
+        if len(_word_tokens(doc.body)) < 100:
+            return []  # N/A: minimal skill, examples not expected
+        return [(0, w, "No examples found — add ## Example sections to show how the skill is used")]
+
+    def _paired(sec: str) -> bool:
+        low = sec.lower()
+        fences = len(re.findall(r"^\s*```", sec, re.MULTILINE))
+        return (
+            fences >= 2
+            or ("input" in low and "output" in low)
+            or ("before" in low and "after" in low)
+        )
+
+    richness = sum(1 for s in sections if _paired(s)) / len(sections)
+    lengths = sorted(len(_word_tokens(s)) for s in sections)
+    median_len = lengths[len(lengths) // 2]
+    depth = clamp01(median_len / 60)
+    s = 0.6 * richness + 0.4 * depth
+    if richness >= 0.8:
+        label = f"{len(sections)} example(s) with clear before/after or input/output pairs"
+    else:
+        label = (
+            f"{len(sections)} example(s) found, but missing input/output structure — "
+            "add Input: and Output: blocks (or code fences) to each example"
+        )
+    return [(round(w * s), w, label)]
+
+
+def dim_progressive_disclosure(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    body = doc.body
+    has_supporting = any(doc.file_cache.get(f) for f in ("reference.md", "examples.md"))
+    body_lines = len(body.splitlines())
+    if not has_supporting and body_lines < 100:
+        return []  # N/A: concise skill without supporting files — follows best practices
+    signals: list[float] = []
+    linked_files: list[str] = []
+    problem_files: list[str] = []
+    body_targets = set(_relative_targets(body))
+    for fname in ("reference.md", "examples.md"):
+        content = doc.file_cache.get(fname)
+        present = content is not None and len(content.strip()) > 0
+        linked = fname in body_targets
+        val = 1.0 if (present and linked) else (0.5 if present else 0.0)
+        signals.append(val)
+        if present and linked:
+            linked_files.append(fname)
+        elif present:
+            problem_files.append(f"{fname} (not linked from SKILL.md)")
+        else:
+            problem_files.append(f"{fname} (absent)")
+    s = sum(signals) / len(signals)
+    if not problem_files:
+        label = "Full doc structure: examples.md and reference.md are linked"
+    elif not linked_files:
+        label = "No supporting docs — consider adding examples.md and reference.md for deeper documentation"
+    else:
+        label = f"Partial docs: {', '.join(linked_files)} linked; {', '.join(problem_files)}"
+    return [(round(w * s), w, label)]
+
+
+def dim_behavioral_config(doc: SkillDoc, w: int) -> list[tuple[int, int, str]]:
+    """Score the 13 behavioral/execution/lifecycle frontmatter fields.
+
+    Returns N/A (empty list) when none of the 13 spec fields appear in the
+    frontmatter, so simple skills that need no configuration are not penalized.
+    For skills that do configure these fields, validity and consistency are
+    checked: correct enum values, proper types, and coherent field combinations
+    (e.g. ``agent`` should accompany ``context: fork``).
+
+    Sub-weights (integer fractions of w, remainder goes to lifecycle):
+      discovery 30%, constraints 40%, execution 20%, lifecycle = remainder.
+    """
+    data = doc.data
+
+    if not any(f in data for f in _BEHAVIORAL_FIELDS):
+        return []  # N/A: no behavioral config present; weight renormalizes away
+
+    disc_w = max(1, w * 3 // 10)
+    con_w = max(1, w * 4 // 10)
+    exec_w = max(1, w * 2 // 10)
+    hook_w = max(1, w - disc_w - con_w - exec_w)
+    items: list[tuple[int, int, str]] = []
+
+    # ------------------------------------------------------------------ #
+    # 1. Discovery configuration                                          #
+    # paths / user-invocable get neutral (0.5) when absent because they  #
+    # are optional; argument-hint is required whenever arguments is set.  #
+    # ------------------------------------------------------------------ #
+    disc_signals: list[float] = []
+    disc_parts: list[str] = []
+
+    if "paths" in data:
+        paths_val = data["paths"]
+        valid = isinstance(paths_val, (str, list)) and bool(paths_val)
+        disc_signals.append(1.0 if valid else 0.0)
+        disc_parts.append(
+            f"paths: {'valid ✓' if valid else 'empty or invalid — provide a glob pattern'}"
+        )
+    else:
+        disc_signals.append(0.5)  # absent: neutral for general-scope skills
+        disc_parts.append("paths: not set (skill applies to all files)")
+
+    if "user-invocable" in data:
+        valid = isinstance(data["user-invocable"], bool)
+        disc_signals.append(1.0 if valid else 0.0)
+        disc_parts.append(f"user-invocable: {'✓' if valid else 'invalid — must be true or false'}")
+    else:
+        disc_signals.append(0.5)  # absent: neutral
+        disc_parts.append("user-invocable: not set (defaults to agent-only)")
+
+    if "arguments" in data:
+        has_hint = "argument-hint" in data and bool(data.get("argument-hint"))
+        disc_signals.append(1.0 if has_hint else 0.0)
+        disc_parts.append(
+            f"argument-hint: {'✓' if has_hint else 'missing — required when arguments is set'}"
+        )
+    elif "argument-hint" in data:
+        disc_signals.append(0.8)  # hint set without arguments: unusual but not wrong
+        disc_parts.append("argument-hint: set (no arguments field — consider adding one)")
+
+    disc_s = sum(disc_signals) / len(disc_signals)
+    items.append((round(disc_w * disc_s), disc_w, "Agent discovery: " + "; ".join(disc_parts)))
+
+    # ------------------------------------------------------------------ #
+    # 2. Behavioral constraints                                           #
+    # Validate types when fields are present; full credit when absent     #
+    # (no constraints is a valid configuration).                          #
+    # ------------------------------------------------------------------ #
+    con_signals: list[float] = []
+    con_parts: list[str] = []
+
+    for key in ("allowed-tools", "disallowed-tools"):
+        if key in data:
+            valid = isinstance(data[key], (str, list))
+            con_signals.append(1.0 if valid else 0.0)
+            con_parts.append(
+                f"{key}: {'valid ✓' if valid else 'invalid — must be a string or list'}"
+            )
+
+    if "disable-model-invocation" in data:
+        valid = isinstance(data["disable-model-invocation"], bool)
+        con_signals.append(1.0 if valid else 0.0)
+        con_parts.append(
+            f"disable-model-invocation: {'✓' if valid else 'invalid — must be true or false'}"
+        )
+
+    if not con_signals:
+        con_s = 1.0  # nothing configured: defaults apply, nothing wrong
+        con_parts.append("no tool restrictions (all tools allowed by default)")
+    else:
+        con_s = sum(con_signals) / len(con_signals)
+    items.append((round(con_w * con_s), con_w, "Tool restrictions: " + "; ".join(con_parts)))
+
+    # ------------------------------------------------------------------ #
+    # 3. Execution configuration                                          #
+    # Validate enum values; check that agent accompanies context:fork.   #
+    # ------------------------------------------------------------------ #
+    exec_signals: list[float] = []
+    exec_parts: list[str] = []
+
+    if "context" in data:
+        ctx = data.get("context")
+        valid_ctx = ctx in _VALID_CONTEXT
+        exec_signals.append(1.0 if valid_ctx else 0.0)
+        exec_parts.append(
+            f"context: {ctx} {'✓' if valid_ctx else '— invalid (only "fork" is allowed)'}"
+        )
+        if valid_ctx and ctx == "fork" and "agent" not in data:
+            exec_signals.append(0.0)
+            exec_parts.append("agent: missing — recommended when context is fork")
+        elif "agent" in data:
+            exec_signals.append(1.0)
+            exec_parts.append(f"agent: {data['agent']} ✓")
+
+    if "effort" in data:
+        val = data.get("effort")
+        valid = val in _VALID_EFFORT
+        exec_signals.append(1.0 if valid else 0.0)
+        exec_parts.append(
+            f"effort: {val} {'✓' if valid else f'— invalid (must be one of: {", ".join(sorted(_VALID_EFFORT))})'}"
+        )
+
+    if "shell" in data:
+        val = str(data.get("shell") or "").lower()
+        valid = val in _VALID_SHELL
+        exec_signals.append(1.0 if valid else 0.0)
+        exec_parts.append(
+            f"shell: {data['shell']} {'✓' if valid else '— invalid (must be bash or powershell)'}"
+        )
+
+    if "model" in data and data.get("model") is not None:
+        exec_signals.append(1.0)  # any non-null model string is structurally valid
+        exec_parts.append(f"model: {data['model']} ✓")
+
+    if not exec_signals:
+        exec_s = 1.0  # no execution overrides: defaults apply, nothing wrong
+        exec_parts.append("no execution overrides (using defaults)")
+    else:
+        exec_s = sum(exec_signals) / len(exec_signals)
+    items.append((round(exec_w * exec_s), exec_w, "Execution settings: " + "; ".join(exec_parts)))
+
+    # ------------------------------------------------------------------ #
+    # 4. Lifecycle hooks                                                  #
+    # hooks must be a non-empty dict when set; absent is fine.            #
+    # ------------------------------------------------------------------ #
+    if "hooks" in data:
+        hooks = data.get("hooks")
+        valid = isinstance(hooks, dict) and len(hooks) > 0
+        hook_s = 1.0 if valid else 0.0
+        hook_label = f"hooks: {'configured ✓' if valid else 'invalid — must be a non-empty object with event keys'}"
+    else:
+        hook_s = 1.0  # absent: lifecycle defaults apply
+        hook_label = "hooks: not set (no lifecycle hooks)"
+    items.append((round(hook_w * hook_s), hook_w, "Lifecycle hooks: " + hook_label))
+
+    return items
+
+
+# --------------------------------------------------------------------------- #
+# Registry: (display name, weight, scorer). Weights sum to 100 for prose-only #
+# skills; skills with behavioral config fields are scored over 110.            #
+# --------------------------------------------------------------------------- #
+
+ScorerFn = Callable[[SkillDoc, int], list[tuple[int, int, str]]]
+BoundScorerFn = Callable[[SkillDoc], list[tuple[int, int, str]]]
+
+
+def _bind(fn: ScorerFn, w: int) -> BoundScorerFn:
+    def bound(doc: SkillDoc) -> list[tuple[int, int, str]]:
+        return fn(doc, w)
+
+    return bound
+
+
+DIMENSIONS: list[tuple[str, int, ScorerFn]] = [
+    ("Metadata & Discovery", 8, dim_metadata),
+    ("Information Density", 15, dim_information_density),  # raised: redundancy = wasted tokens
+    ("Lexical Diversity", 9, dim_lexical_diversity),
+    ("Readability", 10, dim_readability),
+    ("Topic Coverage", 15, dim_topic_coverage),
+    ("Structural Coherence", 13, dim_structural_coherence),
+    ("Code Maintainability", 15, dim_code_maintainability),
+    ("Example Quality", 10, dim_example_quality),
+    ("Progressive Disclosure", 5, dim_progressive_disclosure),  # lowered: more files ≠ better ROI
+    ("Behavioral Configuration", 10, dim_behavioral_config),
+]
+
+# Back-compat alias: the engine iterates (name, scorer) pairs; bind the weight.
+CATEGORY_SCORERS: list[tuple[str, BoundScorerFn]] = [
+    (name, _bind(fn, w)) for name, w, fn in DIMENSIONS
+]

--- a/src/skillspector_quality/state.py
+++ b/src/skillspector_quality/state.py
@@ -1,0 +1,17 @@
+"""Graph state for the quality layer.
+
+Subclasses the upstream ``SkillspectorState`` (a ``total=False`` TypedDict) to add the
+``quality_report`` channel, without touching the upstream package.
+"""
+
+from __future__ import annotations
+
+from skillspector.state import SkillspectorState
+
+
+class QualityState(SkillspectorState, total=False):  # type: ignore[misc, call-arg]
+    """Upstream state plus the quality report produced by ``quality_scorer``."""
+
+    # Serialized QualityReport.to_dict(); a plain dict so it round-trips cleanly
+    # through LangGraph state.
+    quality_report: dict[str, object]

--- a/tests/fixtures/good-skill/SKILL.md
+++ b/tests/fixtures/good-skill/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: invoice-parsing
+description: Parses invoices and extracts totals, line items, and vendor details from PDFs.
+when_to_use: Use when the user uploads an invoice or asks to extract invoice data. Do not use for general document parsing or plain-text extraction.
+metadata:
+  author: Test Author
+  version: 1.0.0
+---
+
+# Invoice Parsing
+
+This skill extracts structured financial data from invoice documents. It identifies the
+vendor, enumerates line items, and reconciles the declared total against the computed sum so
+downstream automation can trust the numbers.
+
+## Overview
+
+- Identify the vendor name, address, and invoice number from the header region.
+- Extract every line item — description, quantity, unit price, and amount — into a table.
+- Compute the subtotal, apply tax, and verify the printed grand total matches.
+
+## Steps
+
+1. Read the uploaded document and detect whether it is a scanned image or native text.
+2. Classify the invoice layout against the known vendor templates.
+3. Extract each field into a normalized JSON structure with explicit types.
+4. Validate arithmetic: the line-item sum plus tax must equal the stated total.
+
+If a required field is missing, fall back to a clearly marked placeholder and flag the record
+for human review. When the layout is ambiguous or two templates match equally well, ask the
+user to confirm the vendor before continuing.
+
+## Output
+
+Return a JSON object containing the vendor block, the ordered list of line items, the
+computed totals, and a confidence score for each extracted field.
+
+```python
+from scripts.parse import parse_invoice
+
+result = parse_invoice(document_text)
+```
+
+Run `scripts/parse.py` for the reference implementation. See [reference](reference.md) for the
+full field dictionary and [examples](examples.md) for worked input/output pairs.

--- a/tests/fixtures/good-skill/examples.md
+++ b/tests/fixtures/good-skill/examples.md
@@ -1,0 +1,30 @@
+# Examples
+
+## Example: simple invoice
+
+Input:
+
+```text
+Vendor: Acme Corp
+Total: $100.00
+```
+
+Output:
+
+```json
+{"vendor": "Acme Corp", "total": 100.0}
+```
+
+## Example: missing total
+
+Input:
+
+```text
+Vendor: Globex
+```
+
+Output:
+
+```json
+{"vendor": "Globex", "total": null, "flag": "missing total"}
+```

--- a/tests/fixtures/good-skill/reference.md
+++ b/tests/fixtures/good-skill/reference.md
@@ -1,0 +1,26 @@
+# Reference
+
+Field definitions and layout heuristics for invoice parsing.
+
+## Vendor block
+
+- `vendor.name` — the legal entity issuing the invoice, taken from the header.
+- `vendor.address` — the billing address printed beneath the name.
+- `vendor.tax_id` — the registration or VAT identifier when present.
+
+## Line items
+
+Each line item is an object with a `description`, a numeric `quantity`, a `unit_price`, and a
+computed `amount`. The parser preserves the original ordering so totals can be audited row by
+row against the source document.
+
+## Totals
+
+The `subtotal` is the sum of line-item amounts. The `tax` is derived from the printed rate,
+and the `total` must equal `subtotal + tax`. A mismatch raises a validation warning rather
+than silently trusting the printed figure.
+
+## Confidence
+
+Every extracted field carries a confidence score between zero and one. Low-confidence fields
+are surfaced for review instead of being dropped, so no information is lost.

--- a/tests/fixtures/good-skill/scripts/parse.py
+++ b/tests/fixtures/good-skill/scripts/parse.py
@@ -1,0 +1,41 @@
+"""Reference invoice parser for the invoice-parsing skill.
+
+Parses raw invoice text into a normalized structure and validates that the line-item
+arithmetic matches the printed total.
+"""
+
+from __future__ import annotations
+
+import re
+
+_LINE_RE = re.compile(r"^(?P<desc>.+?)\s+(?P<qty>\d+)\s+(?P<price>\d+\.\d{2})$")
+
+
+def parse_line_items(text: str) -> list[dict]:
+    """Extract line items from the body of an invoice.
+
+    Each matched row becomes a dict with description, quantity, unit price, and amount.
+    """
+    items: list[dict] = []
+    for line in text.splitlines():
+        match = _LINE_RE.match(line.strip())
+        if not match:
+            continue
+        qty = int(match.group("qty"))
+        price = float(match.group("price"))
+        items.append(
+            {
+                "description": match.group("desc"),
+                "quantity": qty,
+                "unit_price": price,
+                "amount": round(qty * price, 2),
+            }
+        )
+    return items
+
+
+def parse_invoice(text: str) -> dict:
+    """Return a normalized invoice dict with vendor, items, and reconciled totals."""
+    items = parse_line_items(text)
+    subtotal = round(sum(item["amount"] for item in items), 2)
+    return {"items": items, "subtotal": subtotal}

--- a/tests/fixtures/messy-skill/SKILL.md
+++ b/tests/fixtures/messy-skill/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: Messy_Skill
+description: does stuff
+---
+
+# Messy Skill
+
+This skill does stuff. This skill does stuff. This skill does stuff. This skill does stuff.
+This skill does stuff. This skill does stuff. This skill does stuff. This skill does stuff.
+This skill does stuff. This skill does stuff. This skill does stuff. This skill does stuff.
+
+#### Deep Heading Without Parents
+
+See [the missing doc](missing.md) for details.
+
+This skill does stuff. This skill does stuff. This skill does stuff. This skill does stuff.
+This skill does stuff. This skill does stuff. This skill does stuff. This skill does stuff.

--- a/tests/fixtures/messy-skill/notes.md
+++ b/tests/fixtures/messy-skill/notes.md
@@ -1,0 +1,5 @@
+# Cooking Notes
+
+Preheat the oven to 200 degrees. Whisk the eggs with sugar until pale. Fold in the flour
+gently and pour the batter into a greased tin. Bake for twenty five minutes until golden and
+let the sponge cool on a wire rack before dusting with icing.

--- a/tests/fixtures/messy-skill/orphan.md
+++ b/tests/fixtures/messy-skill/orphan.md
@@ -1,0 +1,3 @@
+# Orphan
+
+Nothing links to this file. It is dead weight in the bundle that nobody reaches.

--- a/tests/fixtures/messy-skill/scripts/messy.py
+++ b/tests/fixtures/messy-skill/scripts/messy.py
@@ -1,0 +1,26 @@
+def f(a, b, c, d):
+    if a > 0:
+        if b > 0:
+            if c > 0:
+                if d > 0:
+                    return a + b + c + d
+                else:
+                    return a + b + c
+            else:
+                if d > 0:
+                    return a + b + d
+                else:
+                    return a + b
+        else:
+            if c > 0:
+                return a + c
+            else:
+                return a
+    else:
+        if b > 0:
+            if c > 0:
+                return b + c
+            else:
+                return b
+        else:
+            return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,68 @@
+"""CLI tests — exercises the scan command via Typer's CliRunner."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from typer.testing import CliRunner
+
+from skillspector_quality.cli import app
+
+RUNNER = CliRunner()
+GOOD_FIXTURE = str(pathlib.Path(__file__).parent / "fixtures" / "good-skill")
+
+
+def test_scan_help_exits_zero() -> None:
+    result = RUNNER.invoke(app, ["scan", "--help"])
+    assert result.exit_code == 0
+    assert "input-path" in result.output.lower() or "input_path" in result.output.lower()
+
+
+def test_scan_no_llm_exits_zero() -> None:
+    result = RUNNER.invoke(app, ["scan", GOOD_FIXTURE, "--no-llm"])
+    assert result.exit_code == 0, result.output
+
+
+def test_scan_json_format() -> None:
+    import json
+
+    result = RUNNER.invoke(app, ["scan", GOOD_FIXTURE, "--no-llm", "--format", "json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "quality_assessment" in data
+
+
+def test_scan_markdown_format() -> None:
+    result = RUNNER.invoke(app, ["scan", GOOD_FIXTURE, "--no-llm", "--format", "markdown"])
+    assert result.exit_code == 0, result.output
+    assert "## Quality Assessment" in result.output
+
+
+def test_scan_min_score_gate_fails_when_below_threshold() -> None:
+    result = RUNNER.invoke(app, ["scan", GOOD_FIXTURE, "--no-llm", "--min-score", "99"])
+    assert result.exit_code == 1
+
+
+def test_scan_min_score_gate_passes_when_above_threshold() -> None:
+    result = RUNNER.invoke(app, ["scan", GOOD_FIXTURE, "--no-llm", "--min-score", "1"])
+    assert result.exit_code == 0, result.output
+
+
+def test_scan_nonexistent_path_exits_two() -> None:
+    result = RUNNER.invoke(app, ["scan", "/does/not/exist", "--no-llm"])
+    assert result.exit_code == 2
+
+
+@pytest.mark.integration
+def test_scan_output_file(tmp_path: pathlib.Path) -> None:
+    out = tmp_path / "report.json"
+    result = RUNNER.invoke(
+        app, ["scan", GOOD_FIXTURE, "--no-llm", "--format", "json", "--output", str(out)]
+    )
+    assert result.exit_code == 0
+    assert out.exists()
+    import json
+
+    data = json.loads(out.read_text())
+    assert "quality_assessment" in data

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,75 @@
+"""End-to-end tests: full graph + CLI output merging."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from skillspector_quality.cli import FormatChoice, _merge_output
+from skillspector_quality.quality.models import QualityReport
+
+FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "good-skill"
+
+
+@pytest.fixture(scope="module")
+def graph_result() -> dict:
+    from skillspector_quality.graph import graph
+
+    state = {
+        "input_path": str(FIXTURE),
+        "output_format": "json",
+        "use_llm": False,
+    }
+    return graph.invoke(state)
+
+
+def test_graph_produces_quality_report(graph_result: dict) -> None:
+    assert "quality_report" in graph_result
+    report = QualityReport.from_dict(graph_result["quality_report"])
+    assert report.score >= 70
+
+
+def test_graph_quality_is_deterministic() -> None:
+    from skillspector_quality.graph import graph
+
+    state = {"input_path": str(FIXTURE), "output_format": "json", "use_llm": False}
+    r1 = graph.invoke(dict(state))
+    r2 = graph.invoke(dict(state))
+    assert r1["quality_report"]["score"] == r2["quality_report"]["score"]
+
+
+def test_merge_json_adds_quality_assessment(graph_result: dict) -> None:
+    report = QualityReport.from_dict(graph_result["quality_report"])
+    merged = _merge_output(graph_result, FormatChoice.json, report)
+    data = json.loads(merged)
+    assert "quality_assessment" in data
+    assert "score" in data["quality_assessment"]
+    assert "grade" not in data["quality_assessment"]
+    # Security section preserved.
+    assert "risk_assessment" in data
+
+
+def test_merge_sarif_quality_in_properties(graph_result: dict) -> None:
+    report = QualityReport.from_dict(graph_result["quality_report"])
+    merged = _merge_output(graph_result, FormatChoice.sarif, report)
+    sarif = json.loads(merged)
+    quality = sarif["runs"][0]["properties"]["quality"]
+    assert "score" in quality
+    assert "grade" not in quality
+    # Results stay security-only (no quality entries injected as findings).
+    assert isinstance(sarif["runs"][0].get("results", []), list)
+
+
+def test_merge_markdown_appends_section() -> None:
+    from skillspector_quality.graph import graph
+
+    # report_body must be markdown for this assertion, so scan with markdown format.
+    result = graph.invoke(
+        {"input_path": str(FIXTURE), "output_format": "markdown", "use_llm": False}
+    )
+    report = QualityReport.from_dict(result["quality_report"])
+    merged = _merge_output(result, FormatChoice.markdown, report)
+    assert "## Quality Assessment" in merged
+    assert "SkillSpector Security Report" in merged  # upstream body preserved

--- a/tests/test_quality_scorer.py
+++ b/tests/test_quality_scorer.py
@@ -1,0 +1,47 @@
+"""Tests for the quality_scorer node and its no-LLM guarantees."""
+
+from __future__ import annotations
+
+from skillspector_quality.nodes.quality_scorer import quality_scorer
+from skillspector_quality.quality import score_quality
+from skillspector_quality.quality.models import QualityReport
+
+_SKILL = "---\ndescription: d\nwhen_to_use: use it when needed here\n---\n# Body\n- one\n- two\n"
+
+
+def test_node_returns_quality_report_no_llm() -> None:
+    state = {"file_cache": {"SKILL.md": _SKILL}, "use_llm": False}
+    out = quality_scorer(state)
+    assert "quality_report" in out
+    report = QualityReport.from_dict(out["quality_report"])
+    assert 0 <= report.score <= 100
+    # No LLM -> no notes anywhere.
+    assert all(c.notes is None for c in report.categories)
+
+
+def test_node_matches_engine_no_llm() -> None:
+    state = {"file_cache": {"SKILL.md": _SKILL}, "use_llm": False}
+    out = quality_scorer(state)
+    direct = score_quality({"SKILL.md": _SKILL})
+    assert out["quality_report"]["score"] == direct.score
+
+
+def test_node_empty_file_cache() -> None:
+    out = quality_scorer({"file_cache": {}, "use_llm": False})
+    report = QualityReport.from_dict(out["quality_report"])
+    assert report.score < 40  # nothing meaningful in cache → low score
+
+
+def test_llm_failure_degrades_silently(monkeypatch) -> None:
+    # Force commentary to raise; node must still return the deterministic report.
+    import skillspector_quality.quality.commentary as commentary
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("no network")
+
+    monkeypatch.setattr(commentary, "add_notes", _boom)
+    state = {"file_cache": {"SKILL.md": _SKILL}, "use_llm": True}
+    out = quality_scorer(state)
+    report = QualityReport.from_dict(out["quality_report"])
+    assert report.score == score_quality({"SKILL.md": _SKILL}).score
+    assert all(c.notes is None for c in report.categories)

--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -1,0 +1,412 @@
+"""Unit tests for the math-grounded quality dimensions."""
+
+from __future__ import annotations
+
+import pathlib
+
+from skillspector_quality.quality import score_quality
+from skillspector_quality.quality.scorers import (
+    SkillDoc,
+    _build_idf,
+    _compression_ratio,
+    _cosine,
+    _mtld,
+    _ngram_dup,
+    _python_maintainability,
+    _readability_grades,
+    _terms,
+    _tfidf_vec,
+    _when_specificity,
+    dim_behavioral_config,
+    dim_code_maintainability,
+    dim_example_quality,
+    dim_information_density,
+    dim_metadata,
+    dim_progressive_disclosure,
+    dim_structural_coherence,
+    dim_topic_coverage,
+)
+
+
+def _doc(skill_md: str, **files: str) -> SkillDoc:
+    cache = {"SKILL.md": skill_md}
+    cache.update(files)
+    return SkillDoc.from_file_cache(cache)
+
+
+def _cache_of(name: str) -> dict[str, str]:
+    base = pathlib.Path(__file__).parent / "fixtures" / name
+    return {str(p.relative_to(base)): p.read_text() for p in base.rglob("*") if p.is_file()}
+
+
+# --- information theory ------------------------------------------------------ #
+
+
+def test_compression_ratio_redundant_below_dense() -> None:
+    redundant = "the cat sat on the mat. " * 50
+    dense = (
+        "Heterogeneous pipelines reconcile asynchronous ledgers while validating "
+        "cryptographic provenance across federated jurisdictions and audit trails."
+    )
+    assert _compression_ratio(redundant) < _compression_ratio(dense)
+
+
+def test_ngram_dup_detects_repetition() -> None:
+    repeated = ["this", "skill", "does", "stuff"] * 10
+    varied = "alpha beta gamma delta epsilon zeta eta theta iota kappa".split()
+    assert _ngram_dup(repeated) > 0.3
+    assert _ngram_dup(varied) == 0.0
+
+
+def test_information_density_penalizes_redundancy() -> None:
+    dense_prose = (
+        "Invoices arrive as scanned images or native text. The parser classifies layout "
+        "against vendor templates, then extracts header metadata, line items, and totals. "
+        "Arithmetic reconciliation compares the printed grand total with the computed sum, "
+        "raising a warning whenever rounding, missing tax, or duplicate rows break equality. "
+        "Confidence scores accompany every field so reviewers triage ambiguous extractions "
+        "instead of trusting opaque heuristics blindly."
+    )
+    dense = _doc("---\ndescription: d\n---\n" + dense_prose)
+    redundant = _doc("---\ndescription: d\n---\n" + ("This skill does stuff. " * 60))
+    ((dense_earned, _, _),) = dim_information_density(dense, 12)
+    ((red_earned, _, _),) = dim_information_density(redundant, 12)
+    assert dense_earned > red_earned
+
+
+# --- lexical diversity (length-invariant) ----------------------------------- #
+
+
+def test_mtld_diverse_above_repetitive() -> None:
+    diverse = (
+        "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu "
+        "nu xi omicron pi rho sigma tau upsilon"
+    ).split() * 3
+    repetitive = ["spam", "eggs"] * 30
+    assert _mtld(diverse) > _mtld(repetitive)
+
+
+def test_mtld_is_length_stable() -> None:
+    base = "the quick brown fox jumps over a lazy dog near the river bank".split()
+    short = base * 2
+    long = base * 8
+    # MTLD should stay in the same ballpark regardless of length (unlike TTR).
+    assert abs(_mtld(short) - _mtld(long)) < 0.4 * _mtld(short)
+
+
+# --- readability ------------------------------------------------------------ #
+
+
+def test_readability_grades_returns_five() -> None:
+    text = " ".join(["The parser validates each field and reconciles the total carefully."] * 5)
+    grades, words = _readability_grades(text)
+    assert len(grades) == 5
+    assert words >= 30
+
+
+def test_readability_too_little_prose_is_na() -> None:
+    grades, _ = _readability_grades("short text")
+    assert grades == []
+
+
+# --- topic coverage (TF-IDF) ------------------------------------------------ #
+
+
+def test_tfidf_cosine_aligned_above_offtopic() -> None:
+    corpus = [
+        _terms("invoice parsing vendor totals line items"),
+        _terms("invoice vendor totals extraction"),
+        _terms("baking cake oven flour sugar eggs"),
+    ]
+    idf = _build_idf(corpus)
+    body = _tfidf_vec(corpus[0], idf)
+    aligned = _tfidf_vec(corpus[1], idf)
+    offtopic = _tfidf_vec(corpus[2], idf)
+    assert _cosine(body, aligned) > _cosine(body, offtopic)
+
+
+def test_topic_coverage_rewards_on_topic_docs() -> None:
+    skill = "---\ndescription: invoice vendor totals parsing\n---\n# Invoice\nParse invoice vendor totals and line items.\n"
+    on_topic = _doc(skill, **{"reference.md": "Invoice vendor totals and line items reference."})
+    off_topic = _doc(skill, **{"reference.md": "Cake baking oven flour sugar eggs recipe."})
+    ((on_earned, _, _),) = dim_topic_coverage(on_topic, 15)
+    ((off_earned, _, _),) = dim_topic_coverage(off_topic, 15)
+    assert on_earned > off_earned
+
+
+# --- structural coherence (graph + heading tree) ---------------------------- #
+
+
+def test_structure_detects_heading_skip() -> None:
+    good = _doc("---\nd: 1\n---\n# Title\n## Section\n### Sub\n")
+    skipped = _doc("---\nd: 1\n---\n# Title\n#### Deep\n")
+    ((good_earned, _, _),) = dim_structural_coherence(good, 13)
+    ((skip_earned, _, lbl),) = dim_structural_coherence(skipped, 13)
+    assert good_earned > skip_earned
+    assert "skip" in lbl
+
+
+def test_structure_penalizes_broken_links_and_orphans() -> None:
+    connected = _doc(
+        "---\nd: 1\n---\n# Title\nSee [ref](reference.md).\n",
+        **{"reference.md": "x"},
+    )
+    broken = _doc(
+        "---\nd: 1\n---\n# Title\nSee [missing](missing.md).\n",
+        **{"orphan.md": "nobody links here"},
+    )
+    ((conn_earned, _, _),) = dim_structural_coherence(connected, 13)
+    ((broken_earned, _, _),) = dim_structural_coherence(broken, 13)
+    assert conn_earned > broken_earned
+
+
+# --- code maintainability (radon + ast) ------------------------------------- #
+
+
+def test_python_maintainability_documented_above_spaghetti() -> None:
+    clean = '''"""Module docstring."""
+
+
+def add(a, b):
+    """Return the sum."""
+    return a + b
+'''
+    spaghetti = (
+        "def f(a,b,c,d):\n"
+        + "".join(f"{' ' * 4}if a>{i}:\n{' ' * 8}return b\n" for i in range(12))
+        + "    return 0\n"
+    )
+    s_clean, m_clean = _python_maintainability(clean)
+    s_bad, m_bad = _python_maintainability(spaghetti)
+    assert s_clean > s_bad
+    assert m_clean["docstring_cov"] == 1.0
+    assert m_bad["docstring_cov"] == 0.0
+
+
+def test_code_maintainability_na_without_scripts() -> None:
+    doc = _doc("---\nd: 1\n---\n# Title\nNo scripts here.\n")
+    assert dim_code_maintainability(doc, 15) == []  # N/A -> omitted
+
+
+# --- metadata + examples ---------------------------------------------------- #
+
+
+def test_metadata_completeness() -> None:
+    full = _doc(
+        "---\nname: my-skill\ndescription: d\n"
+        "when_to_use: Use when the user asks to parse invoices or extract line items. "
+        "Do not use for general text processing or plain search.\n"
+        "metadata:\n  author: A\n  version: 1.0\n---\n# T\n"
+    )
+    ((earned, mx, _),) = dim_metadata(full, 8)
+    assert (earned, mx) == (8, 8)
+
+
+def test_metadata_when_to_use_specificity() -> None:
+    specific = "Use when the user uploads an invoice. Do not use for general text extraction."
+    vague = "This skill helps with things when needed."
+    absent = ""
+    assert _when_specificity(specific) >= 0.8
+    assert _when_specificity(vague) < _when_specificity(specific)
+    assert _when_specificity(absent) == 0.0
+    # Absent → neutral (0.5) in scoring, not zero — optional field
+    doc_specific = _doc(f"---\nname: s\ndescription: d\nwhen_to_use: {specific}\n---\n# T\n")
+    doc_vague = _doc(f"---\nname: s\ndescription: d\nwhen_to_use: {vague}\n---\n# T\n")
+    ((s_earned, _, _),) = dim_metadata(doc_specific, 8)
+    ((v_earned, _, _),) = dim_metadata(doc_vague, 8)
+    assert s_earned > v_earned
+
+
+def test_metadata_optional_fields_not_penalized() -> None:
+    minimal = _doc(
+        "---\nname: my-skill\ndescription: Processes invoices and extracts totals.\n---\n# T\n"
+    )
+    ((earned, mx, _),) = dim_metadata(minimal, 8)
+    assert earned >= mx // 2  # optional absent fields → neutral (0.5), not zero
+
+
+def test_progressive_disclosure_na_for_simple_skill() -> None:
+    doc = _doc("---\nname: my-skill\ndescription: d\n---\n# Title\nShort body.\n")
+    assert dim_progressive_disclosure(doc, 7) == []  # N/A: concise, no supporting files needed
+
+
+def test_example_quality_paired_vs_none() -> None:
+    paired = _doc(
+        "---\nd: 1\n---\n# T\n",
+        **{"examples.md": "## Example one\nInput:\n```\na\n```\nOutput:\n```\nb\n```\n"},
+    )
+    none = _doc("---\nd: 1\n---\n# T\nNo examples at all.\n")
+    ((paired_earned, _, _),) = dim_example_quality(paired, 10)
+    assert paired_earned > 0
+    # Minimal body with no examples → N/A (not penalized for being concise)
+    assert dim_example_quality(none, 10) == []
+
+
+def test_example_quality_penalizes_long_skill_with_no_examples() -> None:
+    long_body = "---\nd: invoice totals\n---\n" + (
+        "## Step\nValidate each invoice field and reconcile totals carefully.\n" * 20
+    )
+    result = dim_example_quality(_doc(long_body), 10)
+    assert result != []  # substantial skill (>100 words) → not N/A
+    ((earned, _, _),) = result
+    assert earned == 0  # no examples → zero score
+
+
+# --- engine aggregation ----------------------------------------------------- #
+
+
+def test_score_quality_normalized() -> None:
+    r = score_quality({"SKILL.md": "---\ndescription: d\n---\n# Body\nSome prose here today.\n"})
+    assert 0 <= r.score <= 100
+
+
+def test_na_dimension_omitted_from_report() -> None:
+    # No scripts -> Code Maintainability must not appear among categories.
+    r = score_quality(_cache_of("good-skill"))
+    names = {c.name for c in r.categories}
+    r_noscript = score_quality(
+        {k: v for k, v in _cache_of("good-skill").items() if not k.startswith("scripts/")}
+    )
+    assert "Code Maintainability" in names
+    assert "Code Maintainability" not in {c.name for c in r_noscript.categories}
+
+
+def test_deterministic_repeatable() -> None:
+    cache = _cache_of("good-skill")
+    assert score_quality(cache).to_dict() == score_quality(cache).to_dict()
+
+
+# --- fixtures (discrimination) ---------------------------------------------- #
+
+
+def test_good_fixture_scores_well() -> None:
+    r = score_quality(_cache_of("good-skill"))
+    assert r.score >= 70
+
+
+def test_messy_fixture_scores_poorly() -> None:
+    good = score_quality(_cache_of("good-skill"))
+    messy = score_quality(_cache_of("messy-skill"))
+    assert messy.score < good.score
+    assert messy.score < 50  # N/A renormalization raises the floor; still clearly poor
+
+
+# --- behavioral configuration (gap analysis) --------------------------------- #
+
+
+def test_behavioral_config_na_without_spec_fields() -> None:
+    doc = _doc(
+        "---\nname: my-skill\ndescription: d\nwhen_to_use: use when needed\n"
+        "metadata:\n  author: A\n  version: 1.0\n---\n# T\n"
+    )
+    assert dim_behavioral_config(doc, 10) == []
+
+
+def test_behavioral_config_sub_weights_sum_to_w() -> None:
+    doc = _doc(
+        "---\nname: s\ncontext: fork\nagent: general-purpose\neffort: high\n"
+        "paths: '**/*.py'\nallowed-tools: [Read, Grep]\nhooks:\n  stop: [echo done]\n---\n# T\n"
+    )
+    items = dim_behavioral_config(doc, 10)
+    assert sum(m for _, m, _ in items) == 10
+
+
+def test_behavioral_config_valid_paths_scores_above_empty_paths() -> None:
+    valid = _doc("---\nname: s\npaths: '**/*.py'\n---\n# T\n")
+    empty = _doc("---\nname: s\npaths: ''\n---\n# T\n")  # set but empty → invalid
+    assert sum(e for e, _, _ in dim_behavioral_config(valid, 10)) > sum(
+        e for e, _, _ in dim_behavioral_config(empty, 10)
+    )
+
+
+def test_behavioral_config_argument_hint_required_with_arguments() -> None:
+    no_hint = _doc("---\nname: s\narguments: [issue-number]\n---\n# T\n")
+    with_hint = _doc(
+        "---\nname: s\narguments: [issue-number]\nargument-hint: '[issue-number]'\n---\n# T\n"
+    )
+    assert sum(e for e, _, _ in dim_behavioral_config(with_hint, 10)) > sum(
+        e for e, _, _ in dim_behavioral_config(no_hint, 10)
+    )
+
+
+def test_behavioral_config_invalid_effort_penalized() -> None:
+    bad = _doc("---\nname: s\neffort: supermax\n---\n# T\n")
+    good = _doc("---\nname: s\neffort: high\n---\n# T\n")
+    assert sum(e for e, _, _ in dim_behavioral_config(good, 10)) > sum(
+        e for e, _, _ in dim_behavioral_config(bad, 10)
+    )
+
+
+def test_behavioral_config_invalid_shell_penalized() -> None:
+    bad = _doc("---\nname: s\nshell: zsh\n---\n# T\n")
+    good = _doc("---\nname: s\nshell: bash\n---\n# T\n")
+    assert sum(e for e, _, _ in dim_behavioral_config(good, 10)) > sum(
+        e for e, _, _ in dim_behavioral_config(bad, 10)
+    )
+
+
+def test_behavioral_config_context_fork_without_agent_penalized() -> None:
+    no_agent = _doc("---\nname: s\ncontext: fork\n---\n# T\n")
+    with_agent = _doc("---\nname: s\ncontext: fork\nagent: general-purpose\n---\n# T\n")
+    assert sum(e for e, _, _ in dim_behavioral_config(with_agent, 10)) > sum(
+        e for e, _, _ in dim_behavioral_config(no_agent, 10)
+    )
+
+
+def test_behavioral_config_invalid_hooks_type_penalized() -> None:
+    bad_hooks = _doc("---\nname: s\nhooks: 'a string'\n---\n# T\n")
+    good_hooks = _doc("---\nname: s\nhooks:\n  stop:\n    - echo done\n---\n# T\n")
+    assert sum(e for e, _, _ in dim_behavioral_config(good_hooks, 10)) > sum(
+        e for e, _, _ in dim_behavioral_config(bad_hooks, 10)
+    )
+
+
+def test_behavioral_config_invalid_allowed_tools_type_penalized() -> None:
+    bad = _doc("---\nname: s\nallowed-tools:\n  key: value\n---\n# T\n")  # dict, not str/list
+    good = _doc("---\nname: s\nallowed-tools: [Read, Grep]\n---\n# T\n")
+    assert sum(e for e, _, _ in dim_behavioral_config(good, 10)) > sum(
+        e for e, _, _ in dim_behavioral_config(bad, 10)
+    )
+
+
+def test_behavioral_config_user_invocable_must_be_bool() -> None:
+    bad = _doc("---\nname: s\nuser-invocable: 'yes'\n---\n# T\n")
+    good = _doc("---\nname: s\nuser-invocable: false\n---\n# T\n")
+    assert sum(e for e, _, _ in dim_behavioral_config(good, 10)) > sum(
+        e for e, _, _ in dim_behavioral_config(bad, 10)
+    )
+
+
+def test_behavioral_config_appears_in_engine_report() -> None:
+    r = score_quality(
+        {
+            "SKILL.md": "---\nname: s\ncontext: fork\nagent: general-purpose\neffort: high\n---\n# T\n"
+        }
+    )
+    names = {c.name for c in r.categories}
+    assert "Behavioral Configuration" in names
+
+
+# --- length-neutrality (the reframe) ---------------------------------------- #
+
+
+def test_more_good_content_not_penalized_but_filler_is() -> None:
+    section = (
+        "## Step\nValidate each invoice field and reconcile the printed total against the "
+        "computed sum so downstream automation can trust the extracted numbers.\n"
+    )
+    base = "---\ndescription: invoice totals validation\n---\n# Invoice\n" + section
+    # Doubling genuine, distinct content (new vocabulary, different concepts) must not tank score.
+    distinct_section = (
+        "## Exception handling\nWhen a vendor file is missing or corrupt, fall back to the "
+        "last known snapshot and notify the finance team, logging the discrepancy for audit.\n"
+    )
+    more_good = base + distinct_section
+    filler = base + ("This skill does stuff. " * 60)
+
+    s_base = score_quality({"SKILL.md": base}).score
+    s_more = score_quality({"SKILL.md": more_good}).score
+    s_filler = score_quality({"SKILL.md": filler}).score
+
+    assert s_more >= s_base - 5  # added good content is not punished
+    assert s_filler < s_more  # redundant filler is punished


### PR DESCRIPTION
## Summary

- Adds a deterministic 0–100 quality score for Claude Code skills (SKILL.md bundles), complementing SkillSpector's security risk score in a single unified report.
- Scoring is a **pure function of the skill's files** — no LLM, no randomness, identical results across machines and CI runs.
- Dimensions are informed by peer-reviewed research on agent context file ROI ([Gloaguen et al. 2026, arXiv:2602.11988](https://arxiv.org/abs/2602.11988)): redundant prose is penalized (token cost), specific `when_to_use` conditions are rewarded (task success), and the scoring is length-neutral throughout.

## What's included

| Area | Files |
|------|-------|
| Quality scorer (10 dimensions) | `src/skillspector_quality/quality/scorers.py` |
| LangGraph integration node | `src/skillspector_quality/nodes/quality_scorer.py` |
| CLI (`scan` command) | `src/skillspector_quality/cli.py` |
| Output rendering (terminal / JSON / SARIF / markdown) | `src/skillspector_quality/quality/render.py` |
| Optional LLM advisory notes | `src/skillspector_quality/quality/commentary.py` |
| Unit tests (36 tests, all passing) | `tests/test_scorers.py` |
| CI/CD recipes (GitHub Actions, GitLab) | `README.md` |
| OpenSSF community health files | `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md` |

## Quality dimensions

| Dimension | Weight | Key signal |
|-----------|--------|-----------|
| Metadata & Discovery | 8 | `when_to_use` specificity: trigger verbs + exclusion conditions |
| Information Density | 15 | Compression ratio + 5-gram duplication (redundancy = token waste) |
| Lexical Diversity | 9 | MTLD — length-invariant vocabulary richness |
| Readability | 10 | Ensemble of 5 grade-level formulas, target 8–14th grade |
| Topic Coverage | 15 | TF-IDF cosine between description and body |
| Structural Coherence | 13 | Heading-tree + link-graph reachability |
| Code Maintainability | 15 | radon MI, cyclomatic complexity, docstring coverage |
| Example Quality | 10 | Paired input/output detection |
| Progressive Disclosure | 5 | `examples.md` / `reference.md` reachability |
| Behavioral Configuration | 10 | 13 spec fields validated in 4 groups |

## Research basis

Scoring adjustments are grounded in **Gloaguen et al. 2026** ([arXiv:2602.11988](https://arxiv.org/abs/2602.11988)), which found:
- LLM-generated context files cost +20–23 % more tokens with no task-success benefit
- Specific trigger + exclusion conditions in `when_to_use` yield the highest ROI (+4 % task success)
- More linked supporting files increase agent token spend without proportional gains

## Test plan

- [ ] `python -m pytest tests/test_scorers.py` — 36 tests pass
- [ ] `python -m skillspector_quality scan tests/fixtures/good-skill/ --no-llm` — score ≥ 70
- [ ] `python -m skillspector_quality scan tests/fixtures/messy-skill/ --no-llm` — score < 50
- [ ] `python -m skillspector_quality scan tests/fixtures/good-skill/ --format json` — valid JSON output
- [ ] `ruff check src/ tests/` — no violations
- [ ] `mypy src/` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)