### PR TITLE
ci: add OSSF Scorecard supply-chain security workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Adds the [OSSF Scorecard Action](https://github.com/marketplace/actions/ossf-scorecard-action) workflow
- Runs on push to `main`, weekly (Mondays 01:30 UTC), and on branch protection rule changes
- Uploads results as SARIF to the GitHub Security tab

## Test plan

- [ ] Confirm the workflow triggers after merge
- [ ] Check the Security tab for Scorecard results

🤖 Generated with [Claude Code](https://claude.com/claude-code)